### PR TITLE
call label service with, like, actual data

### DIFF
--- a/behaviors/text.js
+++ b/behaviors/text.js
@@ -1,13 +1,11 @@
 'use strict';
-var label = require('../services/label'),
-  dom = require('../services/dom');
+var dom = require('../services/dom');
 
 module.exports = function (result, args) {
   var el = result.el,
     bindings = result.bindings;
 
   // add some stuff to the bindings
-  bindings.label = label(bindings.name);
   bindings.required = args.required;
 
   var tpl = `

--- a/services/behaviors.js
+++ b/services/behaviors.js
@@ -2,6 +2,7 @@
 var _ = require('lodash'),
   rivets = require('rivets'),
   references = require('./references'),
+  label = require('./label'),
   // hash of all behaviors
   behaviorsHash = {},
   // has of current bindings
@@ -42,7 +43,15 @@ function runBehaviors(name, partials) {
       console.log('Behavior "' + behaviorName + '" not found. Make sure you add it!');
       return result;
     }
-  }, { el: document.createDocumentFragment(), bindings: { data: data, name: name, path: path }, rivets: rivets });
+  }, { el: document.createDocumentFragment(), bindings: { data: data, name: name, path: path, label: label(path, schema) }, rivets: rivets });
+  /*
+  ~= BINDINGS ADDED BY DEFAULT =~
+  `el` is a new document fragment that behaviors can attach to (or replace)
+  `data` is the data for that field
+  `name` is the property key of that field, e.g. long
+  `path` is the full path from the top of the form to that field, e.g. title.long
+  `label` is the nicely-formatted label for that field, e.g. "Your Long Title" (from _label) or "Title » Long" (generated from the path)
+   */
 
   // use the rivets instance that was passed through the behaviors, since it may have formatters/etc added to it
   bindingsHash[name] = done.rivets.bind(done.el, done.bindings); // compile and bind templates, persist them to bindingsHash
@@ -66,7 +75,7 @@ function expandBehavior(behavior) {
      *   required: true
      */
     key = behavior[references.behaviorKey]; // hold onto this reference
-    return { fn: key, args: _.omit(behavior, key) };
+    return { fn: key, args: _.omit(behavior, references.behaviorKey) };
   } else {
     throw new Error('Cannot parse behavior: ' + behavior);
   }

--- a/services/behaviors.test.js
+++ b/services/behaviors.test.js
@@ -11,6 +11,7 @@ describe('behaviors service', function () {
     });
 
     it('gets a behavior defined as an object', function () {
+      console.log(b.getExpandedBehaviors({ fn: 'foo', baz: 'qux' }))
       expect(b.getExpandedBehaviors({ fn: 'foo', baz: 'qux' })).to.eql([{
         fn: 'foo',
         args: { baz: 'qux' }

--- a/services/formcreator.js
+++ b/services/formcreator.js
@@ -44,7 +44,7 @@ function createField(fieldName, partials, display) {
     // once we're done iterating, put those in a section
     finalEl = dom.create(`
       <section class="editor-section">
-        <h2 class="editor-section-head">${label(fieldName)}</h2>
+        <h2 class="editor-section-head">${label(fieldName, schema)}</h2>
         <div class="editor-section-body">
       </section>
     `);
@@ -131,7 +131,7 @@ function createForm(name, options) {
   });
 
   // build up form el
-  finalEl = createModalEl(createModalFormEl(label(name), innerEl));
+  finalEl = createModalEl(createModalFormEl(label(name, schema), innerEl));
   // append it to the body
   document.body.appendChild(finalEl);
 


### PR DESCRIPTION
We weren't calling `label()` with the schema, so it was automatically falling back to using the name.

Also, passing it into the bindings by default, since it's sort of top level.

Also, added comments explaining the things we're adding to bindings.
