### PR TITLE
forms.close and unfocus

### DIFF
--- a/controllers/form.js
+++ b/controllers/form.js
@@ -29,7 +29,6 @@ module.exports = function () {
       select.setHeight(oldEl);
     }
 
-    this.el = el;
     this.ref = ref;
     this.path = path;
     this.oldEl = oldEl;
@@ -59,12 +58,10 @@ module.exports = function () {
     },
 
     closeForm: function () {
-      var el = this.el,
-        oldEl = this.oldEl;
+      var oldEl = this.oldEl;
 
       focus.unfocus();
       dom.unwrapElements(oldEl, dom.find(oldEl, '.hidden-wrapped'));
-      oldEl.removeChild(el);
     }
   };
 

--- a/controllers/modal.js
+++ b/controllers/modal.js
@@ -2,14 +2,9 @@ module.exports = function () {
   var dom = require('../services/dom'),
     focus = require('../services/focus');
 
-  function constructor(el) {
-    var modal = dom.find(el, '.editor-modal');
-
+  function constructor() {
     // set noscroll on the html when a modal opens
     dom.find('html').classList.add('noscroll');
-
-    this.overlay = el;
-    this.modal = modal;
   }
 
   constructor.prototype = {
@@ -18,12 +13,9 @@ module.exports = function () {
     },
 
     close: function (e) {
-      var overlay = this.overlay;
-
       if (e.target === e.currentTarget) {
         // we clicked on the overlay itself
         focus.unfocus();
-        dom.removeElement(overlay);
         dom.find('html').classList.remove('noscroll');
       }
     }

--- a/services/focus.js
+++ b/services/focus.js
@@ -5,25 +5,25 @@ var _ = require('lodash'),
   currentFocus; // eslint-disable-line
 
 /**
- * set focus on an Element
- * @param {Element} el
- * @param {{ref: string, path: string, data: object}} options
- * @param {MouseEvent} e
- */
-function focus(el, options, e) {
-  select.unselect();
-  select.select(el);
-  currentFocus = el;
-  forms.open(options.ref, el, options.path, e);
-}
-
-/**
  * remove focus
  */
 function unfocus() {
   select.unselect();
   currentFocus = null;
   forms.close();
+}
+
+/**
+ * set focus on an Element
+ * @param {Element} el
+ * @param {{ref: string, path: string, data: object}} options
+ * @param {MouseEvent} e
+ */
+function focus(el, options, e) {
+  unfocus(); // unfocus the potentialy-opened current form first
+  select.select(el);
+  currentFocus = el;
+  forms.open(options.ref, el, options.path, e);
 }
 
 /**

--- a/services/forms.js
+++ b/services/forms.js
@@ -49,9 +49,13 @@ function open(ref, el, path, e) {
  * @param {Element} [el] optional element to replace (for inline forms)
  */
 function close() {
-  // var form = dom.find('.editor') || dom.find('.editor-inline');
+  var formContainer = dom.find('.editor-modal-overlay') || dom.find('.editor-inline');
+
   // todo: when we have autosave, this is a point where it should save
 
+  if (formContainer) {
+    dom.removeElement(formContainer);
+  }
 }
 
 exports.open = open;

--- a/services/forms.test.js
+++ b/services/forms.test.js
@@ -81,5 +81,42 @@ describe(dirname, function () {
         return fn('fakeRef', stubNode(), 'title').then(checkForms);
       });
     });
+
+    describe('close', function () {
+      var fn = lib[this.title];
+
+      it('closes inline forms', function () {
+        var el = stubNode(),
+          formContainer = document.createElement('div');
+
+        formContainer.classList.add('editor-inline');
+        el.appendChild(formContainer);
+        document.body.appendChild(el);
+
+        fn();
+        expect(el.childNodes.length).to.equal(0);
+      });
+
+      it('closes modal forms', function () {
+        var el = stubNode(),
+          formContainer = document.createElement('div');
+
+        formContainer.classList.add('editor-modal-overlay');
+        el.appendChild(formContainer);
+        document.body.appendChild(el);
+
+        fn();
+        expect(el.childNodes.length).to.equal(0);
+      });
+
+      it('doesn\'t break when no forms are open', function () {
+        var el = stubNode();
+
+        document.body.appendChild(el);
+
+        fn();
+        expect(el.childNodes.length).to.equal(0);
+      });
+    });
   });
 });


### PR DESCRIPTION
- updated `form` controller to call `focus.unfocus()` rather than removing the form directly _(inline)_
- updated `modal` controller to call `focus.unfocus()` rather than removing the form directly _(modal)_
- updated `focus` service to unfocus first
- updated `forms` service to include proper `close()` method
- added tests for `forms.open()` and `forms.close()`

![](https://dl.dropboxusercontent.com/s/8zsxhf7fqz653e4/E86F1211-30A4-458C-AD11-B82918B94F01-9189-0000218FADCDCAE2.gif?dl=0)
