### PR TITLE
Adding localStore that syncs with server.

### DIFF
--- a/client.js
+++ b/client.js
@@ -7,6 +7,7 @@ var ds = require('dollar-slice'),
   dom = require('./services/dom'),
   EditorToolbar = require('./controllers/editor-toolbar'),
   select = require('./services/select'),
+  edit = require('./services/edit'),
   pageToolbar;
 
 // manually add built-in behaviors
@@ -55,4 +56,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // because eslint complains if we don't use the new thing we've created.  We will add to this later.
   pageToolbar = new EditorToolbar(dom.find('[' + references.componentAttribute + '="editor-toolbar"]'));
   console.log('toolbar initialized: ', pageToolbar);
+
+  // Start watching after the local cache has been populated.
+  edit.startSync();
 });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash": "^3.8.0",
     "lodash-deep": "^1.6.0",
     "medium-editor": "^5.0.0-alpha.0",
+    "object.observe": "^0.2.4",
     "rivets": "^0.8.1",
     "striptags": "^2.0.2"
   },


### PR DESCRIPTION
Naming does not feel right yet -- could use feedback.

General flow:
- Clones `refData` cache into an object to store/sync component data.
- Object is observed for changes.
- Changes to object are synced to the server.

https://trello.com/c/4XEqGaIN/70-l-autosave
