### PR TITLE
look for closest component before calling setHeight

### DIFF
--- a/controllers/form.js
+++ b/controllers/form.js
@@ -27,7 +27,7 @@ module.exports = function () {
       dom.find('html').addEventListener('click', outsideClickhandler);
 
       // also set the height of the component bar
-      select.setHeight(oldEl);
+      select.setHeight(dom.closest(oldEl, '[' + references.referenceAttribute + ']'));
     }
 
     this.ref = ref;


### PR DESCRIPTION
This fixes a bug in inline forms where it'd try to setHeight on an editable element _inside_ a component, rather than the component `el` itself.
