### PR TITLE
stop link clicks when opening forms

### DIFF
--- a/services/forms.js
+++ b/services/forms.js
@@ -26,6 +26,7 @@ function open(ref, el, path, e) {
   if (!hasOpenInlineForms(el)) {
     if (e) {
       e.stopPropagation();
+      e.preventDefault();
     }
 
     return edit.getData(ref).then(function (data) {


### PR DESCRIPTION
if `data-editable` is inside a link, prevent the link from being clicked when you open a form
