### PR TITLE
push page down in edit mode

### DIFF
--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -23,6 +23,19 @@
   }
 }
 
+// when the editor toolbar is on the screen, push the page content down
+body {
+  padding-top: 50px;
+
+  @media screen and (min-width: 600px) {
+    padding-top: 60px;
+  }
+
+  @media screen and (min-width: 1024px) {
+    padding-top: 70px;
+  }
+}
+
 .editor-toolbar-inner {
   align-items: center;
   display: flex;


### PR DESCRIPTION
because the toolbar is fixed to the top of the screen, this looks good. it doesn't happen in view mode
