### PR TITLE
simple-list selection fixes

### DIFF
--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -63,6 +63,8 @@ module.exports = function (result, args) {
       e.target.nextSibling.focus();
     } else {
       // we currently have the last item selected, so focus the input
+      e.preventDefault();
+      e.stopPropagation(); // stop the current event first
       input.dispatchEvent(new Event('click'));
       input.focus();
     }


### PR DESCRIPTION
- select next, until you get to the last item
- if you try to select the next on the last item, it focuses the input
- if you click backspace on the input, it selects the last item (this was wonky)
