### PR TITLE
allow pasting html

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -384,6 +384,10 @@ module.exports = function (result, args) {
         var textmodel = model.fromElement(dom.create(editable.innerHTML)),
           fragment = model.toElement(textmodel);
 
+        // note: we're using the model-text service to clean up and standardize html
+        // this is in addition to the cleanup that medium-editor does by default,
+        // as well as the options we specified in the cleanTags / cleanReplacements paste config
+
         dom.clearChildren(editable); // clear the current children
         editable.appendChild(fragment); // add the cleaned dom fragment
         observer.setValue(editable.innerHTML);


### PR DESCRIPTION
- anything in the wysiwyg field is passed through `model-text` when pasting
- this gets rid of cruft and allows us to accept pasted html

NOTE: not all rich text editors are supported
- google docs seems to work pretty well (though it removed underlines)
- word 2011 works (and converts underlines to ems)
- evernote (osx) works (and also converts underlines to ems)
- textedit doesn't work at all
- pages works, but adds non-breaking spaces in the beginning of the text (also removes underlines)
- ...?

In order: Google Docs, Word 2011, Evernote, Pages

![screen shot 2015-07-29 at 5 00 16 pm](https://cloud.githubusercontent.com/assets/447522/8969746/627b6302-3613-11e5-9377-ef65968652b8.png)
