### PR TITLE
added page-ref

### DIFF
--- a/behaviors/component-ref.js
+++ b/behaviors/component-ref.js
@@ -1,3 +1,11 @@
+/*
+Component Ref is used to append hidden fields that allow component instances
+to affect other component instances, e.g. article affecting the page title
+
+Component-Ref arguments
+
+selector {string} a query selector that matches the components you want to grab
+ */
 var _ = require('lodash'),
   dom = require('../services/dom'),
   references = require('../services/references');

--- a/behaviors/page-ref.js
+++ b/behaviors/page-ref.js
@@ -1,0 +1,16 @@
+/*
+Page Ref is used to append hidden fields that allow component instances
+to do logic with the URIs and Page IDs on the server-side
+
+Page-Ref has no arguments!
+ */
+
+var dom = require('../services/dom');
+
+module.exports = function (result) {
+  result.bindings.data.value = dom.uri(); // returns the current uri (for now)
+  // todo: if behaviors supported promises, we could get the full page id
+  result.el.appendChild(dom.create(`<input type="hidden" class="input-text" data-field="${result.bindings.name}" rv-value="data.value" />`));
+
+  return result;
+};

--- a/client.js
+++ b/client.js
@@ -26,6 +26,7 @@ behaviors.add('autocomplete', require('./behaviors/autocomplete'));
 behaviors.add('drop-image', require('./behaviors/drop-image'));
 behaviors.add('label', require('./behaviors/label'));
 behaviors.add('segmented-button', require('./behaviors/segmented-button'));
+behaviors.add('page-ref', require('./behaviors/page-ref'));
 
 // add default decorators
 decorators.add(require('./decorators/placeholder'));


### PR DESCRIPTION
Similar to component-ref (the new `affects`, page-ref grabs the current uri (when behaviors can return promises, it'll grab the actual page ref)
