### PR TITLE
trim text strings on save

### DIFF
--- a/services/form-values.js
+++ b/services/form-values.js
@@ -39,6 +39,11 @@ function getValues(data, el) {
     viewData = _.cloneDeep(binding.observer.value());
     // remove any behavior metadata from the bindings
     viewData = removeBehaviorMeta(viewData);
+    // if the data is a string, trim it!
+    if (_.isString(viewData)) {
+      viewData = viewData.replace(/(\u00a0|&nbsp;)/g, ' '); // remove &nbsp;
+      viewData = viewData.trim();
+    }
     data[name] = viewData;
   }
 


### PR DESCRIPTION
[trello ticket](https://trello.com/c/OASfOu30/104-any-spaces-after-the-last-character-in-any-field-should-be-removed-on-save)
