### PR TITLE
focus on first field ALWAYS

### DIFF
--- a/decorators/focus.js
+++ b/decorators/focus.js
@@ -3,6 +3,7 @@ var _ = require('lodash'),
   forms = require('../services/forms'),
   select = require('../services/select'),
   dom = require('../services/dom'),
+  getInput = require('../services/get-input'),
   currentFocus; // eslint-disable-line
 
 function hasCurrentFocus() {
@@ -32,11 +33,19 @@ function focus(el, options, e) {
       select.select(el);
       currentFocus = el;
       return forms.open(options.ref, el, options.path, e).then(function () {
-        var firstField = dom.find('[' + references.fieldAttribute + ']');
+        var firstField = dom.find('[' + references.fieldAttribute + ']'),
+          firstFieldInput;
 
         // focus on the first field in the form we just created
-        if (firstField) {
-          firstField.focus(); // todo: make sure this actually focuses on an input/wysiwyg, e.g. simple-list
+        if (firstField && getInput.isInput(firstField)) {
+          // first field is itself an input
+          firstField.focus();
+        } else if (firstField) {
+          firstFieldInput = getInput(firstField);
+          // first field is a list or something, that contains an input as a child
+          if (firstFieldInput) {
+            firstFieldInput.focus();
+          }
         }
 
         return firstField;

--- a/services/get-input.js
+++ b/services/get-input.js
@@ -5,4 +5,9 @@ function getInput(el) {
   return dom.find(el, 'input') || dom.find(el, 'textarea') || dom.find(el, '.wysiwyg-input');
 }
 
+function isInput(el) {
+  return el && (el.nodeType === 'INPUT' || el.nodeType === 'TEXTAREA' || el.classList.contains('wysiwyg-input'));
+}
+
 module.exports = getInput;
+module.exports.isInput = isInput;


### PR DESCRIPTION
- this updates the focus() to work with simple-list and other fields that aren't themselves inputs (e.g. headline, tags, etc)
- [trello ticket](https://trello.com/c/kREXfEvM/126-when-clicking-byline-should-immediately-be-able-to-enter-text-like-tags)
