### PR TITLE
soft-maxlength treats spaces correctly

### DIFF
--- a/behaviors/soft-maxlength.js
+++ b/behaviors/soft-maxlength.js
@@ -47,6 +47,13 @@ function setStyles(remaining, span, input) {
   }
 }
 
+function cleanValue(value) {
+  var clean = striptags(value);
+
+  clean = clean.replace(/(\u00a0|&nbsp;|&#160;)/ig, ' '); // remove &nbsp;
+  return clean;
+}
+
 module.exports = function (result, args) {
   var el = result.el,
     bindings = result.bindings,
@@ -58,7 +65,7 @@ module.exports = function (result, args) {
 
   bindings.max = args.value;
   rivets.formatters.charsRemaining = function (max, value) {
-    var length = striptags(value).length,
+    var length = cleanValue(value).length,
       remaining = max - length,
       input = getInput(el); // needs to happen after wysiwyg is instantiated
 


### PR DESCRIPTION
- it ignores nonbreaking spaces when calculating characters remaining
- contenteditable is...not good about nonbreaking spaces
- [trello ticket](https://trello.com/c/mCXlMl4Q/125-one-space-is-being-counted-as-six-characters-in-the-headline-teaser-count)

**NOTE:** It still counts other html entities as their full length, since they're saved in the encoded form. e.g. `&` is actually `&amp;` and takes up five characters instead of one. This is expected behavior.
