### PR TITLE
db accepts empty string

### DIFF
--- a/services/db.js
+++ b/services/db.js
@@ -108,6 +108,14 @@ function expectTextResult(target) {
   }
 }
 
+function getJSON(responseText) {
+  if (responseText.length) {
+    return JSON.parse(responseText);
+  } else {
+    return {};
+  }
+}
+
 /**
  * Translate the response into what we expect
  * @param {Element} target
@@ -117,7 +125,7 @@ function expectJSONResult(target) {
   var statusCodeGroup = target.status.toString()[0];
 
   if (statusCodeGroup === '2') {
-    return JSON.parse(target.responseText);
+    return getJSON(target.responseText);
   } else if (statusCodeGroup === '4' || statusCodeGroup === '5') {
     throw new Error(target.status);
   } else {

--- a/services/db.test.js
+++ b/services/db.test.js
@@ -111,6 +111,14 @@ describe('db service', function () {
       });
     });
 
+    it('accepts empty data', function () {
+      respond('');
+
+      return fn('foo').then(function (data) {
+        expect(data).to.deep.equal({});
+      });
+    });
+
     it('throws on bad data', function (done) {
       var data = 'jkfdlsa';
 


### PR DESCRIPTION
- changes `db.get()` to handle empty string responses, e.g. from an empty schema
- added test for this case
- corresponding pr blog pull request: https://github.com/nymag/pr-blog/pull/68
