### PR TITLE
wysiwyg toolbar button fix

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -377,6 +377,11 @@ module.exports = function (result, args) {
   // put the rich text field after the input
   dom.replaceElement(textInput, field);
 
+  /**
+   * match extension names when instantiating medium-editor
+   * @param {string} extname e.g. 'italic'
+   * @returns {Function}
+   */
   function findExtension(extname) {
     return function (ext) {
       return ext.name === extname;


### PR DESCRIPTION
Buttons weren't updating after you created a wysiwyg field the first time. Now they're good every time.

[trello ticket](https://trello.com/c/snoxdpDI/145-issue-w-wysiwyg-toolbar-buttons-not-updating)
