### PR TITLE
updated segmented button styles

### DIFF
--- a/behaviors/segmented-button.scss
+++ b/behaviors/segmented-button.scss
@@ -15,12 +15,18 @@
 
 .segmented-button label {
   background-color: #fff;
-  border: .1rem solid $blue-50;
+  border-left: .1rem solid $blue-75;
+  border-top: .1rem solid $blue-75;
+  border-bottom: .1rem solid $blue-75;
   cursor: pointer;
   display: block;
   float: left;
   margin: 0;
   padding: .4rem .8rem;
+}
+
+.segmented-button label:last-of-type {
+  border-right: .1rem solid $blue-75;
 }
 
 // rounded borders on first and last button


### PR DESCRIPTION
[trello ticket](https://trello.com/c/VbnO6J5r/157-segmented-button-changes-in-image-overlay)
- borders are `1px` all around
- border color is `$blue-75` instead of `$blue-50`
