### PR TITLE
placeholders all have same font

### DIFF
--- a/styleguide/placeholder.scss
+++ b/styleguide/placeholder.scss
@@ -13,4 +13,5 @@
 
 .kiln-placeholder .placeholder-label {
   @include normal-text();
+  @include overlay-copy();
 }


### PR DESCRIPTION
[trello ticket](https://trello.com/c/KWrFvaT6/159-all-placeholder-label-styling-should-match-the-image-placeholder-styling)
![screen shot 2015-08-21 at 9 31 23 am](https://cloud.githubusercontent.com/assets/447522/9409298/6e6a1e02-47e7-11e5-854f-c6bfade9762c.png)
