### PR TITLE
close add-component-panes when focusing a field

### DIFF
--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -224,5 +224,29 @@ function handler(el, options) {
   return el;
 }
 
+/**
+ * close if it's open
+ * @param  {Element} el
+ */
+function closeIfOpen(el) {
+  if (el.classList.contains('open')) {
+    el.classList.remove('open');
+  }
+}
+
+/**
+ * close any open component panes
+ */
+function closePanes() {
+  var buttons = dom.findAll('.open-add-components'),
+    panes = dom.findAll('.add-components-pane');
+
+  _.forEach(buttons, closeIfOpen);
+  _.forEach(panes, closeIfOpen);
+}
+
 module.exports.when = when;
 module.exports.handler = handler;
+
+// close panes when someone unfocuses / focuses a field
+module.exports.closePanes = closePanes;

--- a/decorators/focus.js
+++ b/decorators/focus.js
@@ -4,6 +4,7 @@ var _ = require('lodash'),
   select = require('../services/select'),
   dom = require('../services/dom'),
   getInput = require('../services/get-input'),
+  componentList = require('./component-list'),
   currentFocus; // eslint-disable-line
 
 function hasCurrentFocus() {
@@ -16,6 +17,7 @@ function hasCurrentFocus() {
  */
 function unfocus() {
   select.unselect();
+  componentList.closePanes(); // close any open add-component panes
   currentFocus = null;
   return forms.close();
 }


### PR DESCRIPTION
[trello ticket](https://trello.com/c/rwLp9SqO/161-s-add-component-menu-should-close-when-the-user-s-focus-is-inside-a-component)

Per Morgan, doing this when focusing / unfocusing a field makes the most sense, and allows both things we want:
- users being able to quickly add multiple components
- the form closing if they go in to edit something
