### PR TITLE
better calculating of soft-maxlength character count

### DIFF
--- a/behaviors/soft-maxlength.js
+++ b/behaviors/soft-maxlength.js
@@ -1,4 +1,5 @@
 var striptags = require('striptags'),
+  he = require('he'),
   dom = require('../services/dom'),
   getInput = require('../services/get-input');
 
@@ -57,9 +58,8 @@ function setStyles(remaining, el) {
  * @returns {string}
  */
 function cleanValue(value) {
-  var clean = striptags(value);
+  var clean = he.decode(striptags(value));
 
-  clean = clean.replace(/(\u00a0|&nbsp;|&#160;)/ig, ' '); // remove &nbsp;
   return clean;
 }
 


### PR DESCRIPTION
[trello ticket](https://trello.com/c/ToVURxp0/2-headline)

Now it decodes html entities, so most characters will have a length of 1 (rather than the length of their encoded form, e.g. `&amp;` is 4). Emoji and other double-wide characters will have lengths of 2, because unicode is ~~garbage~~ awesome.
