### PR TITLE
Fix add then drag

### DIFF
--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -21,7 +21,9 @@ function addComponent(pane, field, name) {
 
         return edit.addToParentList({ref: newRef, parentField: field.path, parentRef: field.ref})
           .then(function (newEl) {
-            dom.insertBefore(pane, newEl);
+            var dropArea = pane.previousElementSibling;
+
+            dropArea.appendChild(newEl);
             return render.addComponentsHandlers(newEl);
           });
       });


### PR DESCRIPTION
Fixes bug so that components added to a component list are draggable.

https://trello.com/c/NZk7Kydk/59-m-drag-and-drop-components-that-are-added-from-the-the-add-component-toolbar-at-the-bottom

![gif](http://zippy.gfycat.com/ScarySillyCranefly.gif)
