### PR TITLE
fixed placeholder styles

### DIFF
--- a/styleguide/placeholder.scss
+++ b/styleguide/placeholder.scss
@@ -10,6 +10,7 @@
   width: 100%;
 }
 
+.kiln-placeholder,
 .kiln-placeholder .placeholder-label {
   @include normal-text();
   @include overlay-copy();


### PR DESCRIPTION
[trello ticket](https://trello.com/c/KWrFvaT6/159-bug-all-placeholder-label-styling-should-match-the-image-placeholder-styling)
