### PR TITLE
save before publishing

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -145,7 +145,9 @@ EditorToolbar.prototype = {
   onPublish: function () {
     var el = this.el;
 
-    publish(el);
+    focus.unfocus().then(function () {
+      return publish(el);
+    });
   }
 };
 


### PR DESCRIPTION
fixes first bug in [this trello ticket](https://trello.com/c/KFk41fDG/7-l-error-messaging)

Editor Toolbar will call `focus.unfocus()` before calling publish, fixing the issue where you might lose unsaved data in inline edit forms if you hit publish before closing the form.
