### PR TITLE
added min-height to empty wysiwyg

### DIFF
--- a/behaviors/wysiwyg.scss
+++ b/behaviors/wysiwyg.scss
@@ -4,6 +4,7 @@
 
 .wysiwyg-input {
   cursor: text;
+  min-height: 1.9rem;
   outline: none;
   white-space: normal;
 }


### PR DESCRIPTION
[trello ticket](https://trello.com/c/01sq23AS/78-bug-cursor-not-appearing-when-clicking-into-paragraph-edit)
