### PR TITLE
undefined-is-not-object

### DIFF
--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -55,7 +55,14 @@ function validate(data, schema) {
   }
 
   if (unknownFields.length) {
-    errors.push(new Error('Unknown fields found in data: ' + unknownFields.toString()));
+    // todo: we need to decide:
+
+    // be forgiving; they meant well
+    _.each(unknownFields, function (unknownField) {
+      delete data[unknownField];
+    });
+
+    // unforgiving: errors.push(new Error('Unknown fields found in data: ' + unknownFields.toString()));
   }
 
   // block unusual formatting of data (so the errors_for saving past this point are consistent)

--- a/services/edit/schema-fields.js
+++ b/services/edit/schema-fields.js
@@ -33,7 +33,7 @@ function addSchemaToData(schema, data) {
  * @returns {object}
  */
 function removeSchemaFromData(data) {
-  if (!!data && data.value !== undefined && !!data._schema && _.size(data) === 2) {
+  if (!!data && data.hasOwnProperty('value') && !!data._schema && _.size(data) === 2) {
     // not an object anymore
     return data.value;
   } else if (_.isObject(data)) {

--- a/services/edit/schema-fields.test.js
+++ b/services/edit/schema-fields.test.js
@@ -116,6 +116,10 @@ describe('schema-fields service', function () {
       expect(fn({num: {_schema: {}, value: '123'}, _schema: {num: {}}})).to.deep.equal({num: '123'});
     });
 
+    it('undefined value with schema to undefined value', function () {
+      expect(fn({num: {_schema: {}, value: undefined}, _schema: {num: {}}})).to.deep.equal({num: undefined});
+    });
+
     it('undefined without schema', function () {
       expect(fn({num: undefined})).to.deep.equal({num: undefined});
     });


### PR DESCRIPTION
Currently, any `{_schema: {...}, value: undefined}` is being turned into `{}` instead of `undefined`.  This fixes that.

Also, some fields can sometimes be added to data on server.js `get`, so the editor cannot error when there are extra fields.  It should simply delete the extra fields.
