### PR TITLE
smaller min-width

### DIFF
--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -56,7 +56,7 @@
 
   flex: 0 0 100%;
   margin: 10px 0 20px;
-  min-width: 30rem;
+  min-width: 10rem;
   position: relative;
 }
 


### PR DESCRIPTION
Allows us to use inline forms in tiny areas, like the sidebar.
