### PR TITLE
allow typing < in simple-list

### DIFF
--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -172,7 +172,7 @@ module.exports = function (result) {
       function handleItemKeyEvents(e) {
         var key = keycode(e);
 
-        if (key === 'enter' || key === 'tab' || key === ',') {
+        if (key === 'enter' || key === 'tab' || (key === ',' && e.shiftKey === false)) {
           addItem(e);
         } else if (key === 'delete' || key === 'backspace' || key === 'left') {
           selectLastItem(e);


### PR DESCRIPTION
[trello ticket](https://trello.com/c/9Fy4J6yY/171-bug-can-t-type-in-simple-list)

Check for shift key in `handleItemKeyEvents`
