### PR TITLE
remove-ref

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -76,7 +76,9 @@ function publish(el) {
 function createPage() {
   // todo: allow users to choose their layout / components
 
-  return edit.createPage();
+  return edit.createPage().then(function (url) {
+    location.href = url;
+  });
 }
 
 /**

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -81,7 +81,7 @@ module.exports = function (karma) {
         browser_version: '35.0',
         os: 'OS X',
         os_version: 'Yosemite'
-      },
+      }
       // safari 8 doesn't support template strings
       // safariMac: {
       //   base: 'BrowserStack',

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -209,7 +209,7 @@ function createPage() {
 
   return cache.getDataOnly(newPageUri).then(function (data) {
     return db.create(prefix + pagesRoute, _.omit(data, '_ref')).then(function (res) {
-      location.href = getNewPageUrl(res[refProp]);
+      return getNewPageUrl(res[refProp]);
     });
   });
 }

--- a/services/edit/index.test.js
+++ b/services/edit/index.test.js
@@ -126,6 +126,17 @@ describe('edit service', function () {
         expect(result).to.deep.equal(data);
       });
     });
+
+    it('publishes page without root ref', function () {
+      var data = expectPublish('/thing.html', '/pages/thing');
+
+      cache.getDataOnly.returns(resolveReadOnly({_ref: 'whatever'}));
+      db.save.withArgs(prefix + '/pages/thing@published').returns(resolveReadOnly({}));
+
+      return fn().then(function (result) {
+        expect(result).to.deep.equal(data);
+      });
+    });
   });
 
   describe('removeFromParentList', function () {
@@ -179,6 +190,45 @@ describe('edit service', function () {
 
       return fn({ref: 'newRef', prevRef: 'b', parentField: 'a', parentRef: 'd'}).then(function (el) {
         expect(el instanceof Element).to.equal(true);
+      });
+    });
+  });
+
+  describe('createPage', function () {
+    var fn = lib[this.title];
+
+    it('creates a page from /pages/new', function () {
+      var data = {};
+
+      cache.getDataOnly.returns(resolveReadOnly(data));
+      db.create.returns(Promise.resolve({}));
+
+      return fn().then(function () {
+        sinon.assert.calledWith(cache.getDataOnly, prefix + '/pages/new');
+        sinon.assert.calledWith(db.create, sinon.match.string, data);
+      });
+    });
+
+    it('removes reference from cached data', function () {
+      var data = {_ref: 'something'},
+        expectedData = {};
+
+      cache.getDataOnly.returns(resolveReadOnly(data));
+      db.create.returns(Promise.resolve({}));
+
+      return fn().then(function () {
+        sinon.assert.calledWith(db.create, sinon.match.string, expectedData);
+      });
+    });
+
+    it('returns new url', function () {
+      var data = {};
+
+      cache.getDataOnly.returns(resolveReadOnly(data));
+      db.create.returns(Promise.resolve(data));
+
+      return fn().then(function (url) {
+        expect(url).to.equal('place.com/b');
       });
     });
   });


### PR DESCRIPTION
Patch:
- Remove `_ref` from creating a page and publishing a page

Matching change for https://github.com/nymag/amphora/pull/160
