### PR TITLE
normalize placeholder fonts

### DIFF
--- a/styleguide/placeholder.scss
+++ b/styleguide/placeholder.scss
@@ -14,4 +14,8 @@
 .kiln-placeholder .placeholder-label {
   @include normal-text();
   @include overlay-copy();
+
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
 }


### PR DESCRIPTION
this will prevent placeholder text from being bold / italic / underlined randomly (if the font styles are applied to the item it's a placeholder for)