### PR TITLE
block repeated items in simple-list

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
   },
   // enable the es6 features supported by our browsers / iojs
   "ecmaFeatures": {
+    "arrowFunctions": true,
     "blockBindings": true,
     "forOf": true,
     "objectLiteralDuplicateProperties": true,

--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -153,16 +153,17 @@ module.exports = function (result, args) {
       function addItem(e) {
         var data = observer.value(),
           newText = { text: addEl.value }, // get the new item text
-          val = newText.text;
+          val = newText.text,
+          repeated = hasRepeatedValue(val, data);
 
         // prevent creating newlines or tabbing out of the field
         if (e) {
           e.preventDefault();
         }
 
-        if (val.length && hasRepeatedValue(val, data)) {
+        if (val.length && repeated) {
           addEl.setCustomValidity('Repeated items are not allowed!');
-        } else if (val.length && !hasRepeatedValue(val, data)) {
+        } else if (val.length && !repeated) {
           addEl.setCustomValidity(''); // valid input
           addEl.value = ''; // remove it from the add-item field
           data.push(newText); // put it into the data

--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -144,9 +144,9 @@ module.exports = function (result, args) {
       // returns false if repitition is allowed
       // returns false if repitition is disallowed and items don't repeat
       function hasRepeatedValue(value, data) {
-        var oldItems = _.map(data, item => item.text);
+        var oldItems = _.map(data, item => item.text.toLowerCase());
 
-        return !allowRepeat && _.contains(oldItems, value);
+        return !allowRepeat && _.contains(oldItems, value.toLowerCase());
       }
 
       // add new item from the add-items field

--- a/behaviors/simple-list.test.js
+++ b/behaviors/simple-list.test.js
@@ -23,6 +23,18 @@ describe(dirname, function () {
 
         expect(resultEl.getAttribute(references.fieldAttribute)).to.equal('foo');
       });
+
+      it('defaults to not allowing repeated items', function () {
+        var input = lib(fixture).el.querySelector('input');
+
+        expect(input.getAttribute('data-allow-repeat')).to.equal('false');
+      });
+
+      it('has allowRepeatedItems argument', function () {
+        var input = lib(fixture, { allowRepeatedItems: true }).el.querySelector('input');
+
+        expect(input.getAttribute('data-allow-repeat')).to.equal('true');
+      });
     });
 
     describe('bindings', function () {


### PR DESCRIPTION
* to repeat items, pass in the `allowRepeatedItems` argument
* this uses native `setCustomValidity` to make the input invalid until you try and add a different tag
* [trello ticket](https://trello.com/c/UISBXyTB/198-no-repeated-items-in-simple-lists)
* also added arrow functions to eslintrc
* NOTE: tags are case insensitive for purposes of comparison