### PR TITLE
block form closing if it fails validation

### DIFF
--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -170,7 +170,7 @@ module.exports = function (result, args) {
           observer.setValue(data);
         } else {
           // close the form
-          focus.unfocus();
+          focus.unfocus().catch(_.noop);
         }
       }
 

--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -449,7 +449,7 @@ function initWysiwygBinder(enableKeyboardExtras) {
           handleComponentCreation(editable, observer);
         } else {
           // close the form?
-          focus.unfocus();
+          focus.unfocus().catch(_.noop);
         }
       });
     }

--- a/controllers/form.js
+++ b/controllers/form.js
@@ -24,7 +24,7 @@ module.exports = function () {
         e.preventDefault();
         focus.unfocus().then(function () {
           this.removeEventListener('click', outsideClickhandler); // note: self references <html>
-        });
+        }).catch(_.noop);
       }
     }
 
@@ -50,7 +50,7 @@ module.exports = function () {
 
     closeForm: function (e) {
       e.preventDefault();
-      focus.unfocus();
+      focus.unfocus().catch(_.noop);
     }
   };
 

--- a/controllers/form.js
+++ b/controllers/form.js
@@ -21,8 +21,10 @@ module.exports = function () {
   function constructor(el, ref, path, oldEl) {
     function outsideClickhandler(e) {
       if (!_.contains(e.path, el) && !wasTooltipClicked(e)) {
-        el.dispatchEvent(new CustomEvent('close'));
-        this.removeEventListener('click', outsideClickhandler); // note: this references <html>
+        e.preventDefault();
+        focus.unfocus().then(function () {
+          this.removeEventListener('click', outsideClickhandler); // note: self references <html>
+        });
       }
     }
 

--- a/controllers/overlay.js
+++ b/controllers/overlay.js
@@ -42,7 +42,7 @@ module.exports = function () {
     close: function (e) {
       if (e.target === e.currentTarget) {
         // we clicked on the overlay itself
-        focus.unfocus();
+        focus.unfocus().catch(_.noop);
       }
     }
   };

--- a/decorators/focus.js
+++ b/decorators/focus.js
@@ -63,7 +63,8 @@ function focus(el, options, e) {
 
         return firstField;
       });
-    });
+    }).catch(_.noop); // form didn't close for some reason.
+    // usually because native validation failed
 }
 
 /**

--- a/decorators/focus.js
+++ b/decorators/focus.js
@@ -5,7 +5,7 @@ var _ = require('lodash'),
   dom = require('../services/dom'),
   getInput = require('../services/get-input'),
   componentList = require('./component-list'),
-  currentFocus; // eslint-disable-line
+  currentFocus;
 
 function hasCurrentFocus() {
   return !!currentFocus;
@@ -16,10 +16,14 @@ function hasCurrentFocus() {
  * @returns {Promise}
  */
 function unfocus() {
-  select.unselect();
-  componentList.closePanes(); // close any open add-component panes
-  currentFocus = null;
-  return forms.close();
+  if (forms.isFormValid()) {
+    select.unselect();
+    componentList.closePanes(); // close any open add-component panes
+    currentFocus = null;
+    return forms.close();
+  } else {
+    return Promise.reject();
+  }
 }
 
 /**

--- a/decorators/focus.test.js
+++ b/decorators/focus.test.js
@@ -12,6 +12,7 @@ describe(dirname, function () {
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
       sandbox.stub(select);
+      sandbox.stub(forms, 'isFormValid').returns(true);
     });
 
     afterEach(function () {

--- a/services/forms.js
+++ b/services/forms.js
@@ -197,8 +197,38 @@ function close() {
   return Promise.resolve();
 }
 
+/**
+ * check if the current form is valid (if it exists)
+ * @returns {boolean}
+ */
+function isFormValid() {
+  var formContainer = findFormContainer(),
+    formEl = formContainer && formContainer.querySelector('form'),
+    isValid, hiddenSubmit;
+
+  if (formEl) {
+    isValid = formEl.checkValidity();
+
+    if (!isValid) {
+      // create a hidden submit button
+      hiddenSubmit = document.createElement('input');
+      hiddenSubmit.setAttribute('type', 'submit');
+      hiddenSubmit.classList.add('hidden-submit');
+      // then add it to the form
+      formEl.appendChild(hiddenSubmit);
+      // then trigger a manual click, which will show the validation messages
+      hiddenSubmit.dispatchEvent(new MouseEvent('click'));
+    }
+
+    return isValid;
+  } else {
+    return true;
+  }
+}
+
 exports.open = open;
 exports.close = close;
+exports.isFormValid = isFormValid;
 
 // for tests:
 exports.dataChanged = dataChanged;

--- a/services/forms.test.js
+++ b/services/forms.test.js
@@ -349,8 +349,42 @@ describe(dirname, function () {
         mockFormData.additionalField = {};
         expect(fn(mockServerData, mockFormData)).to.be.true;
       });
-
     });
 
+    describe('isFormValid', function () {
+      var fn = lib[this.title];
+
+      function stubForm(isValid) {
+        var formClass = 'editor-overlay-background',
+          container = document.createElement('div'),
+          form = document.createElement('form'),
+          input = document.createElement('input'),
+          validityMessage = isValid ? '' : 'Not valid';
+
+        // remove any open forms
+        _.each(document.querySelectorAll('.' + formClass), (el) => el.parentNode.removeChild(el));
+
+        // add new form
+        container.classList.add(formClass);
+        input.setCustomValidity(validityMessage);
+        form.appendChild(input);
+        container.appendChild(form);
+        document.body.appendChild(container);
+      }
+
+      it('returns true if no open form', function () {
+        expect(fn()).to.equal(true);
+      });
+
+      it('returns true if valid open form', function () {
+        stubForm(true);
+        expect(fn()).to.equal(true);
+      });
+
+      it('returns false if invalid form', function () {
+        stubForm(false);
+        expect(fn()).to.equal(false);
+      });
+    });
   });
 });

--- a/services/select.js
+++ b/services/select.js
@@ -153,8 +153,9 @@ function addSettingsOption(componentBar, data, ref) {
     el.addEventListener('click', function (e) {
       e.stopPropagation();
       // Open the settings overlay.
-      focus.unfocus();
-      forms.open(ref, document.body);
+      focus.unfocus().then(function () {
+        forms.open(ref, document.body);
+      }).catch(_.noop);
     });
 
     addMenu(componentBar);
@@ -189,10 +190,11 @@ function addParentLabel(componentBar, parentEl) {
   el.addEventListener('click', function (e) {
     e.stopPropagation();
     // Select the parent.
-    focus.unfocus();
-    unselect();
-    select(parentEl);
-    scrollToComponent(parentEl);
+    focus.unfocus().then(function () {
+      unselect();
+      select(parentEl);
+      scrollToComponent(parentEl);
+    }).catch(_.noop);
   });
   componentBar.appendChild(el);
 }

--- a/services/select.js
+++ b/services/select.js
@@ -1,7 +1,8 @@
 // all components get decorated with component bars (which are hidden by default)
 // components that are "selected" get their bar (and their parents' bars) shown
 
-var references = require('./references'),
+var _ = require('lodash'),
+  references = require('./references'),
   dom = require('./dom'),
   edit = require('./edit'),
   focus = require('../decorators/focus'),
@@ -153,8 +154,8 @@ function addSettingsOption(componentBar, data, ref) {
     el.addEventListener('click', function (e) {
       e.stopPropagation();
       // Open the settings overlay.
-      focus.unfocus().then(function () {
-        forms.open(ref, document.body);
+      return focus.unfocus().then(function () {
+        return forms.open(ref, document.body);
       }).catch(_.noop);
     });
 
@@ -190,7 +191,7 @@ function addParentLabel(componentBar, parentEl) {
   el.addEventListener('click', function (e) {
     e.stopPropagation();
     // Select the parent.
-    focus.unfocus().then(function () {
+    return focus.unfocus().then(function () {
       unselect();
       select(parentEl);
       scrollToComponent(parentEl);

--- a/services/select.test.js
+++ b/services/select.test.js
@@ -137,7 +137,7 @@ describe(dirname, function () {
         expect(fn(el, {ref: 'fakeRef'}).classList.contains('component-bar-wrapper')).to.equal(true);
       });
 
-      it('will select the parent component if parent label in the component bar is clicked', function () {
+      it('will select the parent component if parent label in the component bar is clicked', function (done) {
         var el = stubComponent(),
           parent = stubComponent(),
           options = {ref: 'fakeRef', data: {}, path: 'fakePath'};
@@ -157,6 +157,7 @@ describe(dirname, function () {
         setTimeout(function () {
           expect(parent.classList.contains('selected')).to.equal(true); // Parent is selected.
           expect(el.classList.contains('selected')).to.equal(false); // Child is not selected.
+          done();
         }, 100); // allow time for the promise to resolve
       });
 
@@ -184,7 +185,7 @@ describe(dirname, function () {
         expect(el.querySelector('.component-bar .settings')).to.equal(null); // Settings button was not added.
       });
 
-      it('will open settings form if settings button is clicked', function () {
+      it('will open settings form if settings button is clicked', function (done) {
         var el = stubComponent(),
           options = {ref: 'fakeRef', data: {}, path: 'fakePath'};
 
@@ -203,6 +204,7 @@ describe(dirname, function () {
           expect(el.classList.contains('selected')).to.equal(true);
           // the form should be open
           expect(forms.open.calledOnce).to.equal(true);
+          done();
         }, 100); // allow time for the promise to resolve
       });
 

--- a/services/select.test.js
+++ b/services/select.test.js
@@ -4,6 +4,7 @@ var dirname = __dirname.split('/').pop(),
   groups = require('./groups'),
   edit = require('./edit'),
   forms = require('./forms'),
+  focus = require('../decorators/focus'),
   lib = require('./select');
 
 describe(dirname, function () {
@@ -146,14 +147,17 @@ describe(dirname, function () {
         parent.setAttribute(references.referenceAttribute, 'parentRef');
         parent.appendChild(el);
         sandbox.stub(references, 'getComponentNameFromReference').returns('fakeName');
+        sandbox.stub(focus, 'unfocus').returns(Promise.resolve());
         fn(el, options);
         expect(parent.classList.contains('selected')).to.equal(false); // Parent is not selected.
 
         // Trigger click on parent label in the component's bar.
         el.querySelector('.component-bar .parent.label').dispatchEvent(new Event('click'));
 
-        expect(parent.classList.contains('selected')).to.equal(true); // Parent is selected.
-        expect(el.classList.contains('selected')).to.equal(false); // Child is not selected.
+        setTimeout(function () {
+          expect(parent.classList.contains('selected')).to.equal(true); // Parent is selected.
+          expect(el.classList.contains('selected')).to.equal(false); // Child is not selected.
+        }, 100); // allow time for the promise to resolve
       });
 
       it('adds the settings button if the component has settings', function () {
@@ -188,15 +192,18 @@ describe(dirname, function () {
         sandbox.stub(groups, 'getSettingsFields').returns([1]);
         sandbox.stub(references, 'getComponentNameFromReference').returns('fakeName');
         sandbox.stub(forms, 'open', sandbox.spy().withArgs('fakeName', document.body));
+        sandbox.stub(focus, 'unfocus').returns(Promise.resolve());
         fn(el, options);
 
         // Trigger a click on the settings button
         el.querySelector('.component-bar .settings').dispatchEvent(new Event('click'));
 
-        // the component should still be selected
-        expect(el.classList.contains('selected')).to.equal(true);
-        // the form should be open
-        expect(forms.open.calledOnce).to.equal(true);
+        setTimeout(function () {
+          // the component should still be selected
+          expect(el.classList.contains('selected')).to.equal(true);
+          // the form should be open
+          expect(forms.open.calledOnce).to.equal(true);
+        }, 100); // allow time for the promise to resolve
       });
 
       it('will select a component when component is clicked', function () {

--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -99,3 +99,8 @@
 .hidden-wrapped {
   display: none;
 }
+
+// hidden submit button that's added to the form if it's not valid
+.hidden-submit {
+  display: none;
+}


### PR DESCRIPTION
* [trello ticket that prompted this](https://trello.com/c/3wPlH7Bm/55-bug-image-and-video-components-should-not-be-able-to-be-published-with-invalid-urls)
* forms will not close if they have blocking (e.g. native validation) errors
* trying to close form will trigger native validation messages
* other services that try and close forms will hit the validation as well