### PR TITLE
update kiln to use page.url

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -50,7 +50,7 @@ EditorToolbar = function (el) {
   return state.get().then(function (res) {
     if (res.scheduled) {
       state.toggleScheduled(true);
-      progress.open('schedule', `Page is scheduled to be published ${state.formatTime(res.scheduledAt, true)}`);
+      progress.open('schedule', `Page is scheduled to be published ${state.formatTime(res.scheduledAt)}`);
     } else if (res.published) {
       progress.open('publish', `Page is currently live: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
     }

--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -50,7 +50,7 @@ EditorToolbar = function (el) {
   return state.get().then(function (res) {
     if (res.scheduled) {
       state.toggleScheduled(true);
-      progress.open('schedule', `Page is scheduled to be published ${state.formatTime(res.scheduledAt, true)}`);
+      progress.open('schedule', `Page will be published ${state.formatTime(res.scheduledAt, true)}`);
     } else if (res.published) {
       progress.open('publish', `Page is currently live: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
     }

--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -50,7 +50,7 @@ EditorToolbar = function (el) {
   return state.get().then(function (res) {
     if (res.scheduled) {
       state.toggleScheduled(true);
-      progress.open('schedule', `Page is scheduled to be published ${state.formatTime(res.scheduledAt)}`);
+      progress.open('schedule', `Page is scheduled to be published ${state.formatTime(res.scheduledAt, true)}`);
     } else if (res.published) {
       progress.open('publish', `Page is currently live: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
     }

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -1,5 +1,4 @@
 var moment = require('moment'),
-  references = require('../services/references'),
   pane = require('../services/pane'),
   edit = require('../services/edit'),
   rules = require('../validators'),
@@ -12,7 +11,6 @@ module.exports = function () {
   function constructor(el) {
     this.el = el;
     this.form = dom.find(el, '.schedule');
-    this.pageUri = document.documentElement.getAttribute(references.referenceAttribute);
   }
 
   constructor.prototype = {
@@ -24,7 +22,7 @@ module.exports = function () {
     },
 
     onPublishNow: function () {
-      var pageUri = this.pageUri;
+      var pageUri = dom.pageUri();
 
       pane.close();
       progress.start('publish');
@@ -52,7 +50,7 @@ module.exports = function () {
     },
 
     onUnpublish: function () {
-      var pageUri = this.pageUri;
+      var pageUri = dom.pageUri();
 
       pane.close();
       progress.start('publish');
@@ -74,7 +72,7 @@ module.exports = function () {
 
     onSchedule: function (e) {
       var form = this.form,
-        pageUri = this.pageUri,
+        pageUri = dom.pageUri(),
         date = dom.find(form, 'input[type=date]').value,
         time = dom.find(form, 'input[type=time]').value,
         datetime = moment(date + ' ' + time, 'YYYY-MM-DD HH:mm'),
@@ -107,7 +105,7 @@ module.exports = function () {
     },
 
     onUnschedule: function () {
-      var pageUri = this.pageUri;
+      var pageUri = dom.pageUri();
 
       pane.close();
       progress.start('schedule');

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -93,7 +93,7 @@ module.exports = function () {
         })
         .then(function () {
           progress.done();
-          progress.open('schedule', `Publishing scheduled ` + state.formatTime(timestamp, true), true);
+          progress.open('schedule', `Publishing scheduled ` + state.formatTime(timestamp), true);
           state.toggleScheduled(true);
         })
         .catch(function () {

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -93,7 +93,7 @@ module.exports = function () {
         })
         .then(function () {
           progress.done();
-          progress.open('schedule', `Publishing scheduled ` + state.formatTime(timestamp), true);
+          progress.open('schedule', `Publishing scheduled ` + state.formatTime(timestamp, true), true);
           state.toggleScheduled(true);
         })
         .catch(function () {

--- a/services/dom.js
+++ b/services/dom.js
@@ -1,5 +1,6 @@
 var domify = require('domify'),
-  _ = require('lodash');
+  _ = require('lodash'),
+  references = require('./references');
 
 module.exports = {
   /**

--- a/services/dom.js
+++ b/services/dom.js
@@ -16,6 +16,15 @@ module.exports = {
   },
 
   /**
+   * get page uri
+   * note: page uri should be in the data-uri attribute of the <html> element
+   * @returns {string}
+   */
+  pageUri: function () {
+    return document.firstElementChild.getAttribute(references.referenceAttribute);
+  },
+
+  /**
    * This function can be minimized smaller than document.querySelector
    * @param {Element} [el]
    * @param {string} selector

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -370,7 +370,6 @@ module.exports = {
   addToParentList: addToParentList,
   createComponent: createComponent,
   createPage: createPage,
-  createUri: createUri,
   publishPage: publishPage,
   unpublishPage: unpublishPage,
   removeFromParentList: removeFromParentList,

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -162,7 +162,7 @@ function removeUri(uri) {
  * @returns {Promise.string}
  */
 function publishPage() {
-  var pageUri = document.firstElementChild.getAttribute(references.referenceAttribute);
+  var pageUri = dom.pageUri();
 
   return cache.getDataOnly(pageUri).then(function (pageData) {
     // pages don't have schemas or validation
@@ -178,7 +178,7 @@ function publishPage() {
  * @returns {Promise}
  */
 function unpublishPage() {
-  var pageUri = document.firstElementChild.getAttribute(references.referenceAttribute);
+  var pageUri = dom.pageUri();
 
   return cache.getDataOnly(pageUri).then(function (pageData) {
     // change url into uri

--- a/services/edit/index.test.js
+++ b/services/edit/index.test.js
@@ -5,8 +5,7 @@ var lib = require('./'),
   cache = require('./cache'),
   control = require('./control'),
   progress = require('./../progress'),
-  sinon = require('sinon'),
-  references = require('./../references');
+  sinon = require('sinon');
 
 describe('edit service', function () {
   var sandbox,
@@ -39,8 +38,6 @@ describe('edit service', function () {
     site.addPort.returns('place.com/b');
 
     db.getHTML.returns(document.createElement('div'));
-    // page-related actions need the page uri
-    document.firstElementChild.setAttribute(references.referenceAttribute, 'thing');
   });
 
   afterEach(function () {
@@ -54,6 +51,7 @@ describe('edit service', function () {
     it('publishes page with version', function () {
       var data = { url: fakeUrl };
 
+      dom.pageUri.returns('thing');
       cache.getDataOnly.returns(resolveReadOnly(data));
       db.save.withArgs('thing@published').returns(resolveReadOnly(data));
 

--- a/services/edit/index.test.js
+++ b/services/edit/index.test.js
@@ -5,7 +5,8 @@ var lib = require('./'),
   cache = require('./cache'),
   control = require('./control'),
   progress = require('./../progress'),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  references = require('./../references');
 
 describe('edit service', function () {
   var sandbox,
@@ -38,106 +39,26 @@ describe('edit service', function () {
     site.addPort.returns('place.com/b');
 
     db.getHTML.returns(document.createElement('div'));
+    // page-related actions need the page uri
+    document.firstElementChild.setAttribute(references.referenceAttribute, 'thing');
   });
 
   afterEach(function () {
     sandbox.restore();
   });
 
-  describe('getUriDestination', function () {
-    var fn = lib[this.title];
-
-    it('gets page from string', function () {
-      var data = prefix + '/pages/thing';
-
-      db.getText.returns(Promise.resolve(data));
-      dom.uri.throws();
-
-      return fn(prefix + '/thing/thing').then(function (result) {
-        expect(result).to.equal(data);
-      });
-    });
-
-    it('gets page from location', function () {
-      var data = prefix + '/pages/thing';
-
-      db.getText.returns(Promise.resolve(data));
-      dom.uri.returns(prefix + '/thing/thing');
-
-      return fn().then(function (result) {
-        expect(result).to.equal(data);
-      });
-    });
-
-    it('gets page from redirect uri', function () {
-      var redirect = prefix + '/uris/cGxhY2UuY29tL3RoaW5nL3RoaW5n',
-        data = prefix + '/pages/thing';
-
-      db.getText.withArgs(redirect).returns(Promise.resolve(data));
-      db.getText.returns(Promise.resolve(redirect));
-      dom.uri.returns(prefix + '/thing/thing');
-
-      return fn().then(function (result) {
-        expect(result).to.equal(data);
-      });
-    });
-  });
-
   describe('publishPage', function () {
-    var fn = lib[this.title];
-
-    function expectPublish(uri, pageRef) {
-      var data = prefix + pageRef,
-        canonicalUrl = prefix + uri,
-        putData = {canonicalUrl: canonicalUrl};
-
-      dom.uri.returns(canonicalUrl);
-      db.getText.returns(Promise.resolve(data));
-
-      return putData;
-    }
+    var fn = lib[this.title],
+      fakeUrl = 'http://place.com/fake-url.html';
 
     it('publishes page with version', function () {
-      var data = expectPublish('/thing@thing.html', '/pages/thing@otherthing');
+      var data = { url: fakeUrl };
 
-      cache.getDataOnly.returns(resolveReadOnly({}));
-      db.save.withArgs(prefix + '/pages/thing@published').returns(resolveReadOnly(data));
-
-      return fn().then(function (result) {
-        expect(result).to.deep.equal('place.com/pages/thing.html');
-      });
-    });
-
-    it('publishes page without version', function () {
-      var data = expectPublish('/thing.html', '/pages/thing');
-
-      cache.getDataOnly.returns(resolveReadOnly({}));
-      db.save.withArgs(prefix + '/pages/thing@published').returns(resolveReadOnly(data));
+      cache.getDataOnly.returns(resolveReadOnly(data));
+      db.save.withArgs('thing@published').returns(resolveReadOnly(data));
 
       return fn().then(function (result) {
-        expect(result).to.deep.equal('place.com/pages/thing.html');
-      });
-    });
-
-    it('publishes bare page', function () {
-      var data = expectPublish('/pages/thing.html', '/pages/thing');
-
-      cache.getDataOnly.returns(resolveReadOnly({}));
-      db.save.withArgs(prefix + '/pages/thing@published').returns(resolveReadOnly(data));
-
-      return fn().then(function (result) {
-        expect(result).to.deep.equal('place.com/pages/thing.html');
-      });
-    });
-
-    it('publishes page without root ref', function () {
-      var data = expectPublish('/thing.html', '/pages/thing');
-
-      cache.getDataOnly.returns(resolveReadOnly({_ref: 'whatever'}));
-      db.save.withArgs(prefix + '/pages/thing@published').returns(resolveReadOnly(data));
-
-      return fn().then(function (result) {
-        expect(result).to.deep.equal('place.com/pages/thing.html');
+        expect(result).to.deep.equal(data.url);
       });
     });
   });
@@ -255,25 +176,6 @@ describe('edit service', function () {
 
       return fn('fakeName').then(function () {
         expect(cache.createThrough.calledWith(prefix + '/components/fakeName/instances', bootstrapJson)).to.equal(true);
-      });
-    });
-  });
-
-  describe('createUri', function () {
-    var fn = lib[this.title];
-
-    it('adds to db', function () {
-      var url = 'http://domain:3333/path',
-        uri = 'domain/path/some-id',
-        expectedTarget = 'place.com/uris/ZG9tYWluL3BhdGg=',
-        expectedBody = 'domain/path/some-id';
-
-      db.isUrl.returns(true);
-      db.isUri.returns(true);
-      db.saveText.returns(resolveReadOnly({}));
-
-      return fn(url, uri).then(function () {
-        sinon.assert.calledWithExactly(db.saveText, expectedTarget, expectedBody);
       });
     });
   });

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -10,6 +10,10 @@ var _ = require('lodash'),
  * @returns {Promise}
  */
 function getCanonicalUrl() {
+  var 
+
+
+
   var canonical = dom.find('[' + references.referenceAttribute + '*="clay-meta-url"]'),
     ref = canonical && canonical.getAttribute(references.referenceAttribute);
 

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -110,12 +110,12 @@ function toggleScheduled(isScheduled) {
 /**
  * format timestamps in the past and future
  * @param {number} timestamp (unix timestamp)
- * @param {boolean} isFuture
  * @returns {string}
  */
-function formatTime(timestamp, isFuture) {
+function formatTime(timestamp) {
   var datetime = moment(timestamp),
     now = moment(),
+    isFuture = datetime.isAfter(now),
     lowerbound = moment().subtract(3, 'hours'),
     upperbound = moment().add(3, 'hours');
 

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -110,19 +110,19 @@ function toggleScheduled(isScheduled) {
 /**
  * format timestamps in the past and future
  * @param {number} timestamp (unix timestamp)
+ * @param {boolean} isFuture if it should force future tense when the times are the same, e.g. "publishing in a few second!"
  * @returns {string}
  */
-function formatTime(timestamp) {
+function formatTime(timestamp, isFuture) {
   var datetime = moment(timestamp),
     now = moment(),
-    isFuture = datetime.isAfter(now),
     lowerbound = moment().subtract(3, 'hours'),
     upperbound = moment().add(3, 'hours');
 
   if (datetime.isSame(now, 'minute')) {
-    return datetime.fromNow();
-  } else if (datetime.isBetween(lowerbound, upperbound)) {
     return isFuture ? datetime.toNow() : datetime.fromNow();
+  } else if (datetime.isBetween(lowerbound, upperbound)) {
+    return datetime.fromNow();
   } else {
     return datetime.calendar();
   }

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -1,7 +1,6 @@
 var dirname = __dirname.split('/').pop(),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./page-state'),
-  references = require('./references'),
   edit = require('./edit'),
   db = require('./edit/db'),
   dom = require('./dom'),
@@ -9,19 +8,12 @@ var dirname = __dirname.split('/').pop(),
 
 describe(dirname, function () {
   describe(filename, function () {
-    var fakeInstanceRef = 'domain.com/components/clay-meta-url/instances/fakeInstance',
+    var fakePageUri = 'fakePage',
       sandbox, getDataOnly, getHead, get;
-
-    function stubCanonicalUrl() {
-      var el = document.createElement('div');
-
-      el.setAttribute(references.referenceAttribute, fakeInstanceRef);
-      return el;
-    }
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      sandbox.stub(dom, 'find').returns(stubCanonicalUrl());
+      sandbox.stub(dom, 'pageUri').returns(fakePageUri);
       getDataOnly = sandbox.stub(edit, 'getDataOnly');
       getHead = sandbox.stub(db, 'getHead');
       get = sandbox.stub(db, 'get');
@@ -33,7 +25,7 @@ describe(dirname, function () {
 
     describe('get', function () {
       var fn = lib[this.title],
-        scheduleRef = 'null@scheduled',
+        scheduleRef = 'fakePage@scheduled',
         fakeUrl = 'http://domain.com/page.html',
         fakeUri = db.urlToUri(fakeUrl),
         fakeInstanceData = {
@@ -48,27 +40,27 @@ describe(dirname, function () {
 
       it('gets scheduled state (published url is null if not published)', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
-        getDataOnly.withArgs(fakeInstanceRef).returns(Promise.reject());
+        getDataOnly.withArgs(fakePageUri).returns(Promise.reject());
         return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: false, publishedUrl: null }));
       });
 
       it('gets published state (and published url)', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
-        getDataOnly.withArgs(fakeInstanceRef).returns(Promise.resolve(fakeInstanceData));
+        getDataOnly.withArgs(fakePageUri).returns(Promise.resolve(fakeInstanceData));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
         return fn().then(expectState({ scheduled: false, scheduledAt: null, published: true, publishedUrl: fakeUrl }));
       });
 
       it('gets scheduled and published state (and published url)', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
-        getDataOnly.withArgs(fakeInstanceRef).returns(Promise.resolve(fakeInstanceData));
+        getDataOnly.withArgs(fakePageUri).returns(Promise.resolve(fakeInstanceData));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
         return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: true, publishedUrl: fakeUrl }));
       });
 
       it('gets neither state', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
-        getDataOnly.withArgs(fakeInstanceRef).returns(Promise.reject());
+        getDataOnly.withArgs(fakePageUri).returns(Promise.reject());
         return fn().then(expectState({ scheduled: false, scheduledAt: null, published: false, publishedUrl: null }));
       });
     });

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -88,7 +88,9 @@ describe(dirname, function () {
       var fn = lib[this.title];
 
       it('formats now', function () {
-        expect(fn(moment().valueOf())).to.equal(moment().fromNow());
+        var time = moment();
+
+        expect(fn(time.valueOf())).to.equal(time.fromNow());
       });
 
       it('formats now in future tense', function () {

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -94,13 +94,13 @@ describe(dirname, function () {
       it('formats < 3 hours ahead', function () {
         var time = moment().add(30, 'minutes');
 
-        expect(fn(time.valueOf(), true)).to.equal(time.toNow());
+        expect(fn(time.valueOf())).to.equal(time.toNow());
       });
 
       it('formats > 3 hours ahead', function () {
         var time = moment().add(5, 'hours');
 
-        expect(fn(time.valueOf(), true)).to.equal(time.calendar());
+        expect(fn(time.valueOf())).to.equal(time.calendar());
       });
 
       it('formats < 3 hours behind', function () {

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -91,10 +91,16 @@ describe(dirname, function () {
         expect(fn(moment().valueOf())).to.equal(moment().fromNow());
       });
 
+      it('formats now in future tense', function () {
+        var time = moment();
+
+        expect(fn(time.valueOf(), true)).to.equal(time.toNow());
+      });
+
       it('formats < 3 hours ahead', function () {
         var time = moment().add(30, 'minutes');
 
-        expect(fn(time.valueOf())).to.equal(time.toNow());
+        expect(fn(time.valueOf())).to.equal(time.fromNow());
       });
 
       it('formats > 3 hours ahead', function () {


### PR DESCRIPTION
* refactored and simplified `edit.publishPage`
* refactoed and simplified `edit.unpublishPage`
* removed extraneous methods in `edit` services
* added `dom.pageUri` method to get page uri (useful for stubbing when testing)
* simplified `page-state` service