### PR TITLE
kiln stability improvements

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -82,7 +82,14 @@ EditorToolbar.prototype = {
   },
 
   // open the publish pane if it's not already open (close other panes first)
-  onPublishClick: pane.openPublish
+  onPublishClick: function () {
+    return focus.unfocus()
+      .then(pane.openPublish)
+      .catch(function () {
+        progress.done('error');
+        progress.open('error', `Data could not be saved. Please review your open form.`, true);
+      });
+  }
 };
 
 module.exports = EditorToolbar;

--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -67,7 +67,15 @@ EditorToolbar.prototype = {
     e.stopPropagation();
   },
 
-  onNewClick: createPage, // right now, just create a new page
+  onNewClick: function () {
+    if (focus.hasCurrentFocus()) {
+      if(window.confirm('Are you sure you want to create a new page? Your data on this page may not be saved.')) { // eslint-disable-line
+        return createPage();
+      } // else don't leave
+    } else {
+      return createPage();
+    }
+  },
 
   onHistoryClick: function openHistoryPane() {
     // open the history pane if it's not already open (close other panes first)

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -5,7 +5,8 @@ var moment = require('moment'),
   validation = require('../services/publish-validation'),
   progress = require('../services/progress'),
   dom = require('../services/dom'),
-  state = require('../services/page-state');
+  state = require('../services/page-state'),
+  db = require('../services/edit/db');
 
 module.exports = function () {
   function constructor(el) {
@@ -89,7 +90,7 @@ module.exports = function () {
       return edit.unschedulePublish(pageUri).then(function () {
         return edit.schedulePublish({
           at: timestamp,
-          publish: pageUri
+          publish: db.uriToUrl(pageUri)
         })
         .then(function () {
           progress.done();

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -67,7 +67,7 @@ function assertUri(uri) {
  * @param  {string} uri
  * @return {string} uri with port and protocol added, if applicable
  */
-function createUrl(uri) {
+function uriToUrl(uri) {
   return site.addProtocol(site.addPort(uri));
 }
 
@@ -114,7 +114,7 @@ function send(options) {
       };
     }
 
-    request.open(options.method, createUrl(options.url), true);
+    request.open(options.method, uriToUrl(options.url), true);
 
     _.each(options.headers, function (value, key) {
       request.setRequestHeader(key, value);
@@ -368,3 +368,4 @@ module.exports.removeText = removeText;
 module.exports.isUri = isUri;
 module.exports.isUrl = isUrl;
 module.exports.urlToUri = urlToUri;
+module.exports.uriToUrl = uriToUrl;

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -81,7 +81,7 @@ function getPageState() {
 
   return Promise.all([
     getScheduled(pageUri + '@scheduled'),
-    hasCanonicalUrl(pageUri)
+    hasCanonicalUrl(pageUri + '@published')
   ]).then(function (promises) {
     return {
       scheduled: promises[0].scheduled,

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -26,6 +26,7 @@ describe(dirname, function () {
     describe('get', function () {
       var fn = lib[this.title],
         scheduleRef = 'fakePage@scheduled',
+        publishedRef = fakePageUri + '@published',
         fakeUrl = 'http://domain.com/page.html',
         fakeUri = db.urlToUri(fakeUrl),
         fakeInstanceData = {
@@ -40,27 +41,27 @@ describe(dirname, function () {
 
       it('gets scheduled state (published url is null if not published)', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
-        getDataOnly.withArgs(fakePageUri).returns(Promise.reject());
+        getDataOnly.withArgs(publishedRef).returns(Promise.reject());
         return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: false, publishedUrl: null }));
       });
 
       it('gets published state (and published url)', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
-        getDataOnly.withArgs(fakePageUri).returns(Promise.resolve(fakeInstanceData));
+        getDataOnly.withArgs(publishedRef).returns(Promise.resolve(fakeInstanceData));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
         return fn().then(expectState({ scheduled: false, scheduledAt: null, published: true, publishedUrl: fakeUrl }));
       });
 
       it('gets scheduled and published state (and published url)', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
-        getDataOnly.withArgs(fakePageUri).returns(Promise.resolve(fakeInstanceData));
+        getDataOnly.withArgs(publishedRef).returns(Promise.resolve(fakeInstanceData));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
         return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: true, publishedUrl: fakeUrl }));
       });
 
       it('gets neither state', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
-        getDataOnly.withArgs(fakePageUri).returns(Promise.reject());
+        getDataOnly.withArgs(publishedRef).returns(Promise.reject());
         return fn().then(expectState({ scheduled: false, scheduledAt: null, published: false, publishedUrl: null }));
       });
     });
@@ -91,12 +92,6 @@ describe(dirname, function () {
         var time = moment();
 
         expect(fn(time.valueOf())).to.equal(time.fromNow());
-      });
-
-      it('formats now in future tense', function () {
-        var time = moment();
-
-        expect(fn(time.valueOf(), true)).to.equal(time.toNow());
       });
 
       it('formats < 3 hours ahead', function () {


### PR DESCRIPTION
* confirm before creating a new page (if you have forms open)
* save/close forms before opening publish pane (like we did before)
* POST page _url_ instead of page _uri_ to `/schedule`
* look for already-published url in `page@published`, rather than just `page`
* added `db.uriToUrl` to match `db.urlToUri`