### PR TITLE
fixed issue where outside click handler wasn't getting cleared fast enough

### DIFF
--- a/controllers/form.js
+++ b/controllers/form.js
@@ -22,9 +22,8 @@ module.exports = function () {
     function outsideClickhandler(e) {
       if (!_.contains(e.path, el) && !wasTooltipClicked(e)) {
         e.preventDefault();
-        focus.unfocus().then(function () {
-          this.removeEventListener('click', outsideClickhandler); // note: self references <html>
-        }).catch(_.noop);
+        this.removeEventListener('click', outsideClickhandler); // note: self references <html>
+        return focus.unfocus().catch(_.noop);
       }
     }
 


### PR DESCRIPTION
This issue was preventing people from clicking certain things if they'd recently unfocused a form.

* `schedule` button
* `view page` link for already-published pages