### PR TITLE
fixed buttons on firefox

### DIFF
--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -2,7 +2,6 @@
 @import 'typography';
 @import 'buttons';
 @import 'layers';
-
 $height: 60px;
 
 .kiln-toolbar-wrapper {
@@ -43,10 +42,15 @@ body {
 .kiln-toolbar-inner .kiln-toolbar-button, {
   @include button-filled($black-75);
 
-  align-items: center;
-  display: flex;
   flex: 0 0 auto;
   margin: 0 10px 0 0;
+}
+
+.kiln-toolbar-inner .button-flex-inner {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  width: 100%;
 }
 
 .kiln-toolbar-button .icon,
@@ -63,6 +67,7 @@ body {
   @media screen and (min-width: 1024px) {
     display: block;
     margin-left: 10px;
+    padding-top: 1px;
   }
 }
 

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -20,16 +20,22 @@
         <button class="user-icon">{% include 'public/media/components/clay-kiln/user-icon.svg' %}</button>
         <div class="flex-span"></div>
         <button class="kiln-toolbar-button new">
-          <span class="icon">{% include 'public/media/components/clay-kiln/add-icon.svg' %}</span>
-          <span class="text">New Page</span>
+          <div class="button-flex-inner">{# we need this because firefox cannot make buttons display: flex #}
+            <span class="icon">{% include 'public/media/components/clay-kiln/add-icon.svg' %}</span>
+            <span class="text">New Page</span>
+          </div>
         </button>
         <button class="kiln-toolbar-button history">
-          <span class="icon">{% include 'public/media/components/clay-kiln/history-icon.svg' %}</span>
-          <span class="text">History</span>
+          <div class="button-flex-inner">
+            <span class="icon">{% include 'public/media/components/clay-kiln/history-icon.svg' %}</span>
+            <span class="text">History</span>
+          </div>
         </button>
         <button class="kiln-toolbar-button publish">
-          <span class="icon">{% include 'public/media/components/clay-kiln/publish-icon.svg' %}</span>
-          <span class="text">Publish</span>
+          <div class="button-flex-inner">
+            <span class="icon">{% include 'public/media/components/clay-kiln/publish-icon.svg' %}</span>
+            <span class="text">Publish</span>
+          </div>
         </button>
       </div>
       <div>


### PR DESCRIPTION
`<button>` can't be a flex container in firefox, because firefox is bad. https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers