### PR TITLE
firefox height fixes

### DIFF
--- a/styleguide/_inputs.scss
+++ b/styleguide/_inputs.scss
@@ -19,6 +19,11 @@
   white-space: normal;
   width: 100%;
 
+  // firefox height fix
+  &:before {
+    content: "\feff ";
+  }
+
   &.error,
   &:invalid {
     border: 1px solid $red-25;


### PR DESCRIPTION
force firefox to use the correct height for contenteditable (really all input() mixins)