### PR TITLE
fixes for mobile editing, scrolling, zooming, and tapping

### DIFF
--- a/controllers/form.js
+++ b/controllers/form.js
@@ -44,12 +44,18 @@ module.exports = function () {
   constructor.prototype = {
     events: {
       submit: 'closeForm',
-      close: 'closeForm'
+      close: 'closeForm',
+      'input focusin': 'stopFocus',
+      'input focus': 'stopFocus'
     },
 
     closeForm: function (e) {
       e.preventDefault();
       focus.unfocus().catch(_.noop);
+    },
+
+    stopFocus: function (e) {
+      e.preventDefault();
     }
   };
 

--- a/controllers/form.js
+++ b/controllers/form.js
@@ -46,7 +46,9 @@ module.exports = function () {
       submit: 'closeForm',
       close: 'closeForm',
       'input focusin': 'stopFocus',
-      'input focus': 'stopFocus'
+      'input focus': 'stopFocus',
+      '[contenteditable]': 'stopFocus',
+      'select': 'stopFocus'
     },
 
     closeForm: function (e) {

--- a/services/select.js
+++ b/services/select.js
@@ -110,11 +110,16 @@ function when(el) {
  * @param {MouseEvent} e
  */
 function componentClickHandler(el, e) {
-  e.stopPropagation();
+  // allow events to propagate upwards, but set a flag
+  // this allows forms to fire the "outsideClickhandler" to close themselves
+  // while preventing parent components from thinking they're being selected
+  if (!e.stopSelection) {
+    e.stopSelection = true;
 
-  if (!el.classList.contains('selected')) {
-    unselect();
-    select(el);
+    if (!el.classList.contains('selected')) {
+      unselect();
+      select(el);
+    }
   }
 }
 

--- a/styleguide/_typography.scss
+++ b/styleguide/_typography.scss
@@ -16,10 +16,10 @@ $system-fonts: Helvetica, Arial, sans-serif;
 // our typography
 @mixin kiln-copy {
   font-family: $system-fonts;
-  font-size: 14px;
+  font-size: 16px;
   font-style: normal;
   font-weight: 400;
-  line-height: 17px;
+  line-height: 19px;
   text-decoration: none;
 }
 
@@ -52,7 +52,9 @@ $system-fonts: Helvetica, Arial, sans-serif;
 @mixin secondary-text {
   @include kiln-copy();
 
-  color: $black-25;
+  color: $black-50;
+  font-size: 14px;
+  line-height: 17px;
 }
 
 // links

--- a/styleguide/overlay.scss
+++ b/styleguide/overlay.scss
@@ -11,9 +11,11 @@ $overlay-margin: 10vh;
   height: 100%;
   left: 0;
   opacity: 0;
-  overflow: scroll;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
   position: fixed;
   top: 0;
+  transform: translateZ(0); // create a new viewport context
   transition: opacity 100ms ease-out;
   width: 100%;
 

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -85,7 +85,8 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
   display: flex;
   flex: 0 0 auto;
   flex-flow: row wrap;
-  overflow: scroll;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 30px 20px 50px;
 }
 

--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -9,6 +9,7 @@ $height: 60px;
 
   left: 0;
   position: fixed;
+  transform: translateZ(0); // create a new viewport context
   top: calc(100% - #{$height});
   width: 100%;
 }


### PR DESCRIPTION
* set font size to `16px` to prevent mobile zooming (it's also easier to read with my tired old eyes)
* change scrolling styles to (hopefully) prevent forced scrollbars in certain situations
* force offloading of certain fixed position stuff onto the gpu
* fix selection and form closing event handling (so we can close forms ALWAYS, even when selecting components)
* prevent some ios safari weirdness when focusing elements