### PR TITLE
close forms when hitting enter

### DIFF
--- a/controllers/form.js
+++ b/controllers/form.js
@@ -46,9 +46,8 @@ module.exports = function () {
       submit: 'closeForm',
       close: 'closeForm',
       'input focusin': 'stopFocus',
-      'input focus': 'stopFocus',
-      '[contenteditable]': 'stopFocus',
-      'select': 'stopFocus'
+      '[contenteditable] focusin': 'stopFocus',
+      'select focusin': 'stopFocus'
     },
 
     closeForm: function (e) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ gulp.task('scripts', function () {
   // load sourcemaps from browserify
   .pipe(sourcemaps.init({ loadMaps: true }))
   .pipe(uglify())
-  .pipe(sourcemaps.write('.'))
+  .pipe(sourcemaps.write())
   .pipe(gulp.dest('dist'));
 });
 

--- a/services/form-creator.js
+++ b/services/form-creator.js
@@ -60,6 +60,7 @@ function createInlineFormEl(innerEl) {
     <section class="editor editor-inline">
       <form>
         <div class="input-container"></div>
+        <button type="submit" class="hidden-submit"></button>
       </form>
     </section>
   `);

--- a/services/form-creator.test.js
+++ b/services/form-creator.test.js
@@ -128,6 +128,7 @@ describe(dirname, function () {
             <div class="input-container">
               <div class="behaviour-element"></div>
             </div>
+            <button type="submit" class="hidden-submit"></button>
            </form>`));
 
           sandbox.verify();

--- a/services/forms.js
+++ b/services/forms.js
@@ -222,20 +222,16 @@ function close() {
 function isFormValid() {
   var formContainer = findFormContainer(),
     formEl = formContainer && formContainer.querySelector('form'),
-    isValid, hiddenSubmit;
+    isValid, submitButton;
 
   if (formEl) {
     isValid = formEl.checkValidity();
 
     if (!isValid) {
-      // create a hidden submit button
-      hiddenSubmit = document.createElement('input');
-      hiddenSubmit.setAttribute('type', 'submit');
-      hiddenSubmit.classList.add('hidden-submit');
-      // then add it to the form
-      formEl.appendChild(hiddenSubmit);
-      // then trigger a manual click, which will show the validation messages
-      hiddenSubmit.dispatchEvent(new MouseEvent('click'));
+      submitButton = dom.find(formEl, 'button[type="submit"]');
+      // trigger a manual click on the submit button (hidden for inline, shown for overlay),
+      // which will show the validation messages
+      submitButton.dispatchEvent(new MouseEvent('click'));
     }
 
     return isValid;

--- a/services/forms.test.js
+++ b/services/forms.test.js
@@ -359,6 +359,7 @@ describe(dirname, function () {
           container = document.createElement('div'),
           form = document.createElement('form'),
           input = document.createElement('input'),
+          submit = document.createElement('button'),
           validityMessage = isValid ? '' : 'Not valid';
 
         // remove any open forms
@@ -368,6 +369,8 @@ describe(dirname, function () {
         container.classList.add(formClass);
         input.setCustomValidity(validityMessage);
         form.appendChild(input);
+        submit.setAttribute('type', 'submit');
+        form.appendChild(submit);
         container.appendChild(form);
         document.body.appendChild(container);
       }


### PR DESCRIPTION
* cleaned up focus handling (for mobile)
* use inline sourcemaps (it's still not perfect)
* add a (hidden) submit button to all inline forms, so hitting enter will close them
* remove the `hiddenSubmit` logic and just look for the always-available submit button (on both inline and overlay forms)