### PR TITLE
schedule form style fixes

### DIFF
--- a/services/pane.js
+++ b/services/pane.js
@@ -66,9 +66,9 @@ function openPublish() {
     now = moment().format('HH:mm'),
     actions = dom.create(`<div class="actions"></div>`),
     schedule = dom.create(`<form class="schedule">
-      <label class="schedule-label" for="schedule-date">Choose a Date</label>
+      <label class="schedule-label" for="schedule-date">Date</label>
       <input id="schedule-date" class="schedule-input" type="date" min="${today}" value="${today}" placeholder="${today}"></input>
-      <label class="schedule-label" for="schedule-time">Choose a Time</label>
+      <label class="schedule-label" for="schedule-time">Time</label>
       <input id="schedule-time" class="schedule-input" type="time" value="${now}" placeholder="${now}"></input>
       <button class="schedule-publish">Schedule Publish</button>
     </form>`),

--- a/styleguide/_inputs.scss
+++ b/styleguide/_inputs.scss
@@ -6,6 +6,7 @@
 
   background-color: #fff;
   border: 1px solid $black-25;
+  border-radius: 0;
   box-shadow: inset 1px 1px 8px -3px $input-shadow;
   cursor: text;
   display: inline-block;
@@ -25,6 +26,12 @@
   &:invalid {
     border: 1px solid $red-25;
     transition: border 150ms ease-out;
+  }
+
+  &:not([type=checkbox]):not([type=radio]) {
+    // remove things that mobile safari adds to inputs:
+    // rounded borders, untoggleable inset shadows, etc
+    appearance: none;
   }
 }
 

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -109,6 +109,7 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
 
   cursor: initial;
   margin: 0;
+  padding: 8px 10px 7px;
 }
 
 .kiln-toolbar-pane .schedule-input::-webkit-calendar-picker-indicator {


### PR DESCRIPTION
* fields now labeled **Date** and **Time**
* adjusted padding for native pickers (will look slightly narrower on firefox)
* styled mobile safari pickers (and other non-text inputs in mobile safari) to look right
* [trello ticket](https://trello.com/c/87ZXgYLV/232-update-schedule-form)