### PR TITLE
add remove formatting button

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -41,6 +41,9 @@ function toggleTieredToolbar(html) {
  * @returns {Element}
  */
 function createEditor(field, buttons) {
+  // add "remove formatting" button to the end
+  buttons.push('removeFormat');
+
   return new MediumEditor(field, {
     toolbar: {
       // buttons that go in the toolbar


### PR DESCRIPTION
Adds a "remove formatting" button to the end of the wysiwyg toolbar buttons, which allows users to quickly get rid of formatting in their text.

This is very useful if users are copy+pasting from sources that aren't strict about their formatting (CQ, Microsoft Word, etc) and include things like `<span style="custom style stuff">`. Without this button, it's impossible to get rid of those spans in the kiln UI.