### PR TITLE
clone components inside a component list when cloning the parent component

### DIFF
--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -231,7 +231,38 @@ function createComponent(name, data) {
   } else {
     return cache.getDataOnly(base) // create component with base JSON from bootstrap.
       .then(function (baseJson) {
-        return cache.createThrough(instance, baseJson);
+        return cache.createThrough(instance, baseJson).then(function (res) {
+          // after creating the component, see if there are any top-level components inside it
+          // note: it will only look for the first one, since the common case is components having
+          // a componentList with a single empty component, e.g. related-stories or source-links
+          var componentList = _.findKey(res, function (val) {
+              return val._componentList;
+            }),
+            itemRef = componentList && res[componentList][0] && res[componentList][0]._ref;
+
+          // if there is, make sure to create an instance of it
+          if (itemRef && !_.contains(itemRef, '/instances/')) {
+            console.log(itemRef)
+            return cache.getDataOnly(itemRef).then(function (itemBase) {
+              console.log(itemBase)
+              return cache.createThrough(itemRef + '/instances', itemBase).then(function (itemRes) {
+                var newRes = _.cloneDeep(res); // create a new object, since we're explicitly modifying the parent component data
+
+                // then replace the base ref with the new instance
+                // note: if there are other things in the component list of the bare parent component
+                // they will be removed!
+                // todo: make this more generic, to prevent the above ^
+                newRes[componentList] = [{
+                  _ref: itemRes._ref
+                }];
+                console.log(newRes)
+                return cache.saveThrough(newRes);
+              });
+            });
+          } else {
+            return res;
+          }
+        });
       });
   }
 }

--- a/services/edit/index.test.js
+++ b/services/edit/index.test.js
@@ -176,6 +176,83 @@ describe('edit service', function () {
         expect(cache.createThrough.calledWith(prefix + '/components/fakeName/instances', bootstrapJson)).to.equal(true);
       });
     });
+
+    it('clones child component in componentlist', function () {
+      var baseData = {
+          a: [{
+            _ref: prefix + '/components/fakeChild'
+          }]
+        },
+        childData = {
+          _ref: prefix + '/components/fakeChild/instances/0'
+        },
+        newData = {
+          a: [{
+            _ref: prefix + '/components/fakeChild/instances/0'
+          }]
+        };
+
+      // _componentList will normally have properties inside of it
+      baseData.a._componentList = true;
+
+      cache.getDataOnly.withArgs(prefix + '/components/fakeName').returns(resolveReadOnly(baseData));
+      cache.createThrough.withArgs(prefix + '/components/fakeName/instances').returns(resolveReadOnly(baseData));
+      cache.getDataOnly.withArgs(prefix + '/components/fakeChild').returns(resolveReadOnly({}));
+      cache.createThrough.withArgs(prefix + '/components/fakeChild/instances').returns(resolveReadOnly(childData));
+      cache.saveThrough.returnsArg(0);
+
+      return fn('fakeName').then(function (res) {
+        expect(res).to.deep.equal(newData);
+        expect(cache.createThrough.calledWith(prefix + '/components/fakeName/instances', baseData)).to.equal(true);
+        expect(cache.createThrough.calledWith(prefix + '/components/fakeChild/instances')).to.equal(true);
+        expect(cache.saveThrough.calledWith(newData)).to.equal(true);
+      });
+    });
+
+    it('clones multiple child components in componentlist', function () {
+      var baseData = {
+          a: [{
+            _ref: prefix + '/components/fakeChild'
+          }, {
+            _ref: prefix + '/components/fakeChild2'
+          }]
+        },
+        child1Data = {
+          _ref: prefix + '/components/fakeChild/instances/0'
+        },
+        child2Data = {
+          _ref: prefix + '/components/fakeChild2/instances/0'
+        },
+        newData = {
+          a: [{
+            _ref: prefix + '/components/fakeChild/instances/0'
+          }, {
+            _ref: prefix + '/components/fakeChild2/instances/0'
+          }]
+        };
+
+      // _componentList will normally have properties inside of it
+      baseData.a._componentList = true;
+
+      cache.getDataOnly.withArgs(prefix + '/components/fakeName').returns(resolveReadOnly(baseData));
+      cache.createThrough.withArgs(prefix + '/components/fakeName/instances').returns(resolveReadOnly(baseData));
+
+      cache.getDataOnly.withArgs(prefix + '/components/fakeChild').returns(resolveReadOnly({}));
+      cache.createThrough.withArgs(prefix + '/components/fakeChild/instances').returns(resolveReadOnly(child1Data));
+
+      cache.getDataOnly.withArgs(prefix + '/components/fakeChild2').returns(resolveReadOnly({}));
+      cache.createThrough.withArgs(prefix + '/components/fakeChild2/instances').returns(resolveReadOnly(child2Data));
+
+      cache.saveThrough.returnsArg(0);
+
+      return fn('fakeName').then(function (res) {
+        expect(res).to.deep.equal(newData);
+        expect(cache.createThrough.calledWith(prefix + '/components/fakeName/instances', baseData)).to.equal(true);
+        expect(cache.createThrough.calledWith(prefix + '/components/fakeChild/instances')).to.equal(true);
+        expect(cache.createThrough.calledWith(prefix + '/components/fakeChild2/instances')).to.equal(true);
+        expect(cache.saveThrough.calledWith(newData)).to.equal(true);
+      });
+    });
   });
 
   describe('removeUri', function () {


### PR DESCRIPTION
[trello ticket](https://trello.com/c/Kh8swqKX/32-related-stories-new-style)

When you add components via the <kbd>add component</kbd> button, it calls `edit.createComponent` which clones the base data. If that base data contains a component list, this will now clone those components as well.

For example, say I have a component called "Related Stories", that looks like this:

```yaml
components:
  related-stories:
    content:
      -
        _ref: /components/related-story
```

Now that `related-story` will be cloned, rather than having a direct reference to the base data.