### PR TITLE
getHTML should assume edit mode

### DIFF
--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -279,7 +279,7 @@ function getHead(uri) {
 function getHTML(uri) {
   assertUri(uri);
 
-  return send(uri + extHtml).then(expectHTMLResult(uri));
+  return send(uri + extHtml + '?edit=true').then(expectHTMLResult(uri));
 }
 
 /**

--- a/services/render.js
+++ b/services/render.js
@@ -84,7 +84,9 @@ function addComponentsHandlers(el) {
  * @returns {Promise}
  */
 function reloadComponent(ref) {
-  return db.getHTML(ref)
+  return db.getHTML(ref + '?edit=true')
+  // ?edit=true so that components will return back edit-mode stuff (if they check for locals.edit)
+  // e.g. clay-tweet and clay-facebook-post load scripts in view mode, but not edit mode
     .then(function (el) {
       var currentEls = dom.findAll('[' + references.referenceAttribute + '="' + ref + '"]');
 

--- a/services/render.js
+++ b/services/render.js
@@ -84,7 +84,7 @@ function addComponentsHandlers(el) {
  * @returns {Promise}
  */
 function reloadComponent(ref) {
-  return db.getHTML(ref + '?edit=true')
+  return db.getHTML(ref)
   // ?edit=true so that components will return back edit-mode stuff (if they check for locals.edit)
   // e.g. clay-tweet and clay-facebook-post load scripts in view mode, but not edit mode
     .then(function (el) {


### PR DESCRIPTION
this will reload components with ?edit=true, which some components use to determine if they're in edit mode (mostly used for embed components that determine whether or not to load external js