### PR TITLE
only show add-component buttons for selected and parent-selected components

### DIFF
--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -253,11 +253,12 @@ function handler(el, options) {
   button = dom.find(pane, '.open-add-components');
 
   // add click events to toggle pane
-  button.addEventListener('click', function () {
+  button.addEventListener('click', function (e) {
     var addComponentsPane = dom.find(pane, '.add-components-pane');
 
     button.classList.toggle('open');
     addComponentsPane.classList.toggle('open');
+    e.stopPropagation(); // stop unselect() or unfocus() from firing
   });
 
   // wrap the draggable items so that the pane is not in the drop area.

--- a/services/select.js
+++ b/services/select.js
@@ -50,6 +50,33 @@ function getParentComponentListField(componentEl, parentSchema) {
   return path && parentSchema[path] && parentSchema[path][references.componentListProperty] && path;
 }
 
+function walk(node, walker) {
+  if (node && node.classList.contains('component-list-bottom')) {
+    node.classList.add('show');
+  } else if (node) {
+    walk(walker.nextNode(), walker);
+  }
+}
+
+/**
+ * show component lists in element, without showing component lists in child components of element
+ * @param {Element} el
+ */
+function showComponentList(el) {
+  var walker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT, {
+    acceptNode: function (currentNode) {
+      // don't look for component lists in child components
+      if (!currentNode.hasAttribute(references.referenceAttribute)) {
+        return NodeFilter.FILTER_ACCEPT;
+      } else {
+        return NodeFilter.FILTER_REJECT;
+      }
+    }
+  });
+
+  walk(walker.nextNode(), walker);
+}
+
 /**
  * set selection on a component
  * @param {Element} el editable element or component el
@@ -62,18 +89,34 @@ function select(el) {
 
   // selected component gets .selected, parent gets .selected-parent
   component.classList.add('selected');
+  showComponentList(component);
   if (parent) {
     parent.classList.add('selected-parent');
+    showComponentList(parent);
   }
   currentSelected = component;
+}
+
+/**
+ * hide ALL component lists in element
+ * @param {Element} el
+ */
+function hideComponentList(el) {
+  var lists = dom.findAll(el, '.component-list-bottom');
+
+  _.each(lists, function (list) {
+    list.classList.remove('show');
+  });
 }
 
 function removeClasses(el, parent) {
   if (el) {
     el.classList.remove('selected');
+    hideComponentList(el);
   }
   if (parent) {
     parent.classList.remove('selected-parent');
+    hideComponentList(parent);
   }
 }
 

--- a/styleguide/add-component.scss
+++ b/styleguide/add-component.scss
@@ -7,8 +7,17 @@
   @include clearfix();
 
   clear: both;
+  display: none;
   margin: 0 12px 12px 0;
   width: 100%;
+}
+
+.selected-parent .component-list-bottom {
+  display: block;
+}
+
+.selected ~ * .component-list-bottom {
+  display: none;
 }
 
 .open-add-components,

--- a/styleguide/add-component.scss
+++ b/styleguide/add-component.scss
@@ -12,12 +12,8 @@
   width: 100%;
 }
 
-.selected-parent .component-list-bottom {
+.component-list-bottom.show {
   display: block;
-}
-
-.selected ~ * .component-list-bottom {
-  display: none;
 }
 
 .open-add-components,


### PR DESCRIPTION
This will only show the add component buttons / menus for selected components, and for their immediate parent. Some examples:

* You select related-story. You see the plus button for related-stories
* You seelect related-stories. You see the plus button for it and its parent, article
* You select paragraph. You see the plus button for article

This fixes #271 (for the most part, though weird reflows will still happen. They won't be as big a deal now) and has a [trello ticket](https://trello.com/c/IH2kF3Rd/245-plus-buttons-live-inside-parent-component)