### PR TITLE
manual settings group

### DIFF
--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -9,7 +9,7 @@ behaviors/
 
 ## Defined in the schema
 
-Behaviors are added to fields in your `schema.yaml`. They are an array of objects, with a `fn` property and any number of arguments:
+Behaviors are added to fields in your `schema.yaml`. They are an array of strings and objects, with a `fn` property and any number of arguments:
 
 ```yaml
 myField:

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -26,7 +26,7 @@ Besides `_has` (which is an array of behaviors), fields can have certain propert
 
 * **_label:** This is a human-readable label that will be used by the pre-publishing validators, and can also be consumed by the `label` behavior
 * **_display:** This specifies what kind of form the field should use. The options are `inline`, `overlay` (the default), and `settings` (to only display in the component settings form)
-* **_placeholder:** This is an object that specifies what placeholders should be displayed, used primarily when the field's data is empty. You can specify `text` and `height` (a string, e.g. `200px`)
+* **_placeholder:** This is an object that specifies what placeholders should be displayed when the field's data is empty. You can specify `text` and `height` (a string, e.g. `200px`)
 
 #### Defining Behaviors
 
@@ -66,14 +66,22 @@ has_multiple_functions_with_args:
 
 By default, placeholders are displayed when a field is empty. If you would like the placeholder to _always_ appear (e.g. for components with no visible aspects, or for things like ads which rely on client-side js which is suppressed in edit mode), add `permanent: true` to the placeholder object. This will give the placeholder a slightly different styling and prevent it from disappearing when data is added.
 
+```yaml
+adName:
+  _has: text
+  _placeholder:
+    text: AD
+    height: 300px
+    permanent: true
+```
+
 When deciding how to add placeholders, keep these things in mind:
 
 * Placeholders will display when you add `data-editable="fieldName"` or `data-placeholder="fieldName"` (though the latter will _not_ be clickable) to the component's template
-* Placeholder text should invite users to click through and edit the field
-* You can add newlines into placeholder text, either by using yaml's [multiline strings](http://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines) or by adding `\n`, e.g. `text: ARTICLE CONTENT\n\nClick plus button below to add components`
-* Placeholder height should reflect how the component will look when data is added to the field(s). A single line of text will be short, while a component list will probably be taller.
-* Placeholder height is a string, so you may specify different units. Experiment with `vh`, `rems`, and percentages if applicable.
-* Placeholders are specified in the component schema, so all instances of that component will have the same placeholder heights.
+* You can add newlines into placeholder text, either by using yaml's [multiline strings](http://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines) or by adding `\n`, e.g. `text: ARTICLE BODY\n\nClick to add #content`
+* Placeholder height should reflect how the component will look when data is added to the field. A single line of text will be short, while a component list will probably be taller.
+* Placeholder height is a string, so you may specify different units if applicable.
+* Placeholders are specified in the component schema, so all instances of that component will have the same placeholder text, height, and logic.
 
 ### Groups
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -251,7 +251,7 @@ module.exports = function (result, args) {
 The `result` argument contains the field's name, element, data bindings, formatters, and binders.
 
 * **name:** The name of the field, taken directly from the schema
-* **el:** The field's element. Behaviors progressively append elements to this as they're run
+* **el:** The field's element. Behaviors can progressively append elements to this as they're run
 * **bindings:** Data bindings for the field, containing `name`, `label`, and `data`. You can add more data and functions here, based on behavior logic. When all fields are added to the form, rivets will recieve a `bindings` object with each field's bindings, e.g. `{ field1: { bindings }, field2: { bindings } }`
 * **formatters:** [rivets formatters](http://rivetsjs.com/docs/guide/#formatters) that are added at the form level
 * **binders:** [rivets binders](http://rivetsjs.com/docs/guide/#binders) that are added at the form level

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -22,7 +22,7 @@ myField:
 
 ## Referenced in the template
 
-Once a field is defined in the schema, you can add a `data-` attribute to an element in your component's template. When a user clicks on that element, it will open a form containing that field.
+Once a field is defined in the schema, you can add a `data-editable` attribute to an element in your component's template. When a user clicks on that element, it will open a form containing that field.
 
 ```html
 <div data-editable="myField"></div>

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -252,11 +252,21 @@ The `result` argument contains the field's name, element, data bindings, formatt
 
 * **name:** The name of the field, taken directly from the schema
 * **el:** The field's element. Behaviors can progressively append elements to this as they're run
-* **bindings:** Data bindings for the field, containing `name`, `label`, and `data`. You can add more data and functions here, based on behavior logic. When all fields are added to the form, rivets will recieve a `bindings` object with each field's bindings, e.g. `{ field1: { bindings }, field2: { bindings } }`
-* **formatters:** [rivets formatters](http://rivetsjs.com/docs/guide/#formatters) that are added at the form level
-* **binders:** [rivets binders](http://rivetsjs.com/docs/guide/#binders) that are added at the form level
+* **bindings:** Data bindings for the field, containing `name`, `label`, and `data`. You can add more data and functions here, based on behavior logic. When all fields are added to the form, rivets will recieve a `bindings` object with properties for each field (using the field's `name`), e.g. `{ field1: { bindings }, field2: { bindings } }`
+* **formatters:** [Rivets formatters](http://rivetsjs.com/docs/guide/#formatters) are singletons that are added at the form level
+* **binders:** [Rivets binders](http://rivetsjs.com/docs/guide/#binders) are singletons that are added at the form level
 
 Behaviors should return the first argument passed in (the `result` object), but may return a promise that resolves to that object. This is useful if your behavior needs to make api calls or do other async things.
+
+```js
+module.exports = function (result, args) {
+  return fetch(args.url)
+    .then(function (res)) {
+      result.el = res;
+      return result;
+    });
+};
+```
 
 ### Args
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -106,6 +106,30 @@ Component lists don't use `_label` or `_display` (and will ignore them if you sp
 
 **Note:** In the future you will be able to [specify a minimum and maximum number of components](https://github.com/nymag/clay-kiln/issues/298) in your component lists.
 
+#### Defining Display
+
+There are three ways we display fields and forms in Kiln, `inline`, `overlay`, and `settings`. While it is possible to display any field in any of these ways, certain displays are better for certain types of content.
+
+**Inline** is best when there's a one-to-one match between how your component looks and how it's edited. Some examples:
+
+* clicking into a paragraph should display a single inline text area
+* clicking on a header should allow you to edit that header (a single text field) in place
+* clicking on an image should allow you to upload or change that image
+
+**Overlay** is best when there's a one-to-many match between how your component looks and how it's edited. Some examples:
+
+* an article headline looks like a line of text, but has multiple fields for short, medium, social, and seo headlines
+* a link looks like...a link, but has fields for the link text, url, title, and whether it should open in a new tab or not
+
+**Settings** is best when there's a many-to-many match between how your component looks and how it's edited, or when certain fields affect the entirety of a component. Some examples:
+
+* an instance of a share component can enable and disable many social media services at once
+* an article component has data that is never displayed on the article page, but is used to generate rss feeds and sitemaps
+* a paragraph component has a feature to toggle [drop caps](https://www.smashingmagazine.com/2012/04/drop-caps-historical-use-and-current-best-practices/)
+* a feed component has a field that specifies the elasticsearch query it uses to populate items
+
+These are not hard and fast rules, so feel free to experiment!
+
 #### Defining Placeholders
 
 By default, placeholders are displayed when a field is empty. If you would like the placeholder to _always_ appear (e.g. for components with no visible aspects, or for things like ads which rely on client-side js which is suppressed in edit mode), add `permanent: true` to the placeholder object. This will give the placeholder a slightly different styling and prevent it from disappearing when data is added.

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -22,8 +22,10 @@ myField:
 
 ### Field Properties
 
-Besides `_has` (which is an array of behaviors), fields can have certain properties. These are prefixed with underscores.
+Fields can have certain properties. These are prefixed with underscores.
 
+* **_has:** An array of behaviors
+* **_componentList:** A special type of field that contains components. These fields do _not_ have behaviors, labels, or display values, but may have placeholders
 * **_label:** This is a human-readable label that will be used by the pre-publishing validators, and can also be consumed by the `label` behavior
 * **_display:** This specifies what kind of form the field should use. The options are `inline`, `overlay` (the default), and `settings` (to only display in the component settings form)
 * **_placeholder:** This is an object that specifies what placeholders should be displayed when the field's data is empty. You can specify `text` and `height` (a string, e.g. `200px`)
@@ -61,6 +63,40 @@ has_multiple_functions_with_args:
       value: Write stuff here
     - required
 ```
+
+#### Defining Component Lists
+
+Component Lists are a special type of field. These fields don't have behaviors or labels, and don't appear in forms, but rather contain lists of component references and the logic for adding and removing components.
+
+```yaml
+content:
+  _componentList: true
+```
+
+Simply specifying `true` will create a component list that may contain _any_ component installed in your Clay instance (both internal components and any installed via npm). This is used primarily for component lists inside layouts, where users have the maximum amount of creative freedom to add and remove components.
+
+If `_componentList` is an object, you can specify a list of components to `exclude` (blacklisting) or `include` (whitelisting).
+
+```yaml
+# the content of our article, where we ONLY want to include certain components
+articleContent:
+  _componentList:
+    include:
+      - paragraph
+      - image
+
+# a sidebar area where we want to allow every component EXCEPT certain ones
+sideBarArea:
+  _componentList:
+    exclude:
+      - article
+      - paragraph
+      - image
+```
+
+Component lists don't use `_label` or `_display` (and will ignore them if you specify them), but they allow `_placeholder`. It's recommended to add placeholders to component lists, which will display when that list is empty.
+
+**Note:** In the future you will be able to [specify a minimum and maximum number of components](https://github.com/nymag/clay-kiln/issues/298) in your component lists.
 
 #### Defining Placeholders
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -22,7 +22,7 @@ myField:
 
 ### Field Properties
 
-Besides `_has` (which is an array of behaviors), there are certain properties that fields can have, no matter what behaviors they use. These are prefixed with underscores.
+Besides `_has` (which is an array of behaviors), fields can have certain properties. These are prefixed with underscores.
 
 * **_label:** This is a human-readable label that will be used by the pre-publishing validators, and can also be consumed by the `label` behavior
 * **_display:** This specifies what kind of form the field should use. The options are `inline`, `overlay` (the default), and `settings` (to only display in the component settings form)

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -44,23 +44,23 @@ While you can write out all behaviors as an array of objects, there's syntactica
 
 ```yaml
 # If you have a single behavior with no arguments, use a string
-has_one_function_with_no_args:
+hasOneFunctionWithNoArguments:
   _has: text # specifying a string will point to the behavior, e.g. behaviors/text.js
 
 # if you have a single behavior but it has arguments, use an object
-has_one_function_with_args:
+hasOneFunctionWithArguments:
   _has:
     fn: text # fn points to the behavior, e.g. behaviors/text.js
     required: true
 
 # if you have multiple behaviors, use an array
-has_multiple_functions:
+hasMultipleFunctions:
   _has:
     - text
     - label
 
 # you can mix and match strings (behaviors without arguments) and objects (behaviors with arguments) in your arrays
-has_multiple_functions_with_args:
+hasMultipleFunctionsWithArguments:
   _has:
     -
       fn: text

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -193,6 +193,8 @@ _groups:
     _display: inline
 ```
 
+When Kiln generates a form for a group, the `_display` (and `_placeholder`) properties of the individual fields are ignored. This means that you don't have to specify those properties in your fields if they're only used in groups (rather than referenced directly).
+
 If you add a `_placeholder` to a group, you _must_ either make it permanent (with `permanent: true`) _or_ specify a field it should check (with `ifEmpty: fieldName`). It will display the placeholder when that field is empty.
 
 ```yaml
@@ -211,9 +213,9 @@ _groups:
 
 #### Settings Group
 
-By default, Kiln will look through your fields to generate the component settings form. It will add any field with `_display: settings` to the form, but (because schemae are objects) there's no guarantee that the order you write your fields in the schema will be the order they appear in the form.
+By default, Kiln will look through your fields to generate the component settings form. It will add any field with `_display: settings` to the form, but (because schemae are objects) there's no guarantee that the fields' order in the schema will be their order in the form.
 
-If you want to guarantee the field order in your component settings form, you can create the `settings` group manually.
+If you want to guarantee the field order in your component settings form, you can create the `settings` group manually. This will override the default logic, so remember to add all of the fields you want to have in your settings form.
 
 ```yaml
 _groups:
@@ -223,7 +225,7 @@ _groups:
       - url
 ```
 
-You don't need to specify `_label` (the form will be called "<Component Name> Settings"), `_display`, or `_placeholder` for the `settings` group.
+You don't need to specify `_label` (the form will be called "<Component Name> Settings"), `_display`, or `_placeholder` for the `settings` group. If you use it, you also don't need to specify `_display: settings` inside the individual fields.
 
 ## Writing Behaviors
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -170,7 +170,7 @@ url:
 
 _groups:
   myGroup:
-    field:
+    fields:
       - title
       - url
 ```

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -175,13 +175,13 @@ _groups:
       - url
 ```
 
-If you point to the group in your template, it will create a form with all of that group's fields.
+If an element in your template points to that group, clicking it will create a form with all of that group's fields.
 
 ```html
 <div data-editable="myGroup"></div>
 ```
 
-You can add field properties to groups, which will work the same way as with fields.
+You can add field properties to groups, which will work the same way as with fields. Groups can be displayed `inline` as well as in an `overlay`.
 
 ```yaml
 _groups:

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -118,7 +118,7 @@ There are three ways we display fields and forms in Kiln, `inline`, `overlay`, a
 
 **Overlay** is best when there's a one-to-many match between how your component looks and how it's edited. Some examples:
 
-* an article headline looks like a line of text, but has multiple fields for short, medium, social, and seo headlines
+* an article headline looks like a single line of text, but has multiple fields for short, medium, social, and seo headlines
 * a link looks like...a link, but has fields for the link text, url, title, and whether it should open in a new tab or not
 
 **Settings** is best when there's a many-to-many match between how your component looks and how it's edited, or when certain fields affect the entirety of a component. Some examples:

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -14,9 +14,9 @@ Behaviors are added to fields in your `schema.yaml`. They are an array of string
 ```yaml
 myField:
   _has:
-    - text
+    - text # points to behaviors/text.js
     -
-      fn: soft-maxlength
+      fn: soft-maxlength # points to behaviors/soft-maxlength.js
       maxLength: 80
 ```
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -9,7 +9,7 @@ behaviors/
 
 ## Defined in the schema
 
-Behaviors are added to fields in your `schema.yaml`. They are an array of strings and objects, with a `fn` property and any number of arguments:
+Behaviors are added to fields in your `schema.yaml`. They are an array of strings and/or objects (with a `fn` property and any number of arguments):
 
 ```yaml
 myField:
@@ -35,12 +35,12 @@ While you can write out all behaviors as an array of objects, there's syntactica
 ```yaml
 # If you have a single behavior with no arguments, use a string
 has_one_function_with_no_args:
-  _has: text
+  _has: text # specifying a string will point to the behavior, e.g. behaviors/text.js
 
 # if you have a single behavior but it has arguments, use an object
 has_one_function_with_args:
   _has:
-    fn: text
+    fn: text # fn points to the behavior, e.g. behaviors/text.js
     required: true
 
 # if you have multiple behaviors, use an array

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -185,7 +185,7 @@ _groups:
 
 #### Settings Group
 
-By default, kiln will look through your fields to generate the component settings form. It will add any field with `_display: settings` to the form, but (because schemae are objects) there's no guarantee that the order you write your fields in the schema will be the order they appear in the form.
+By default, Kiln will look through your fields to generate the component settings form. It will add any field with `_display: settings` to the form, but (because schemae are objects) there's no guarantee that the order you write your fields in the schema will be the order they appear in the form.
 
 If you want to guarantee the field order in your component settings form, you can create the `settings` group manually.
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -20,6 +20,14 @@ myField:
       maxLength: 80
 ```
 
+## Referenced in the template
+
+Once a field is defined in the schema, you can add a `data-` attribute to an element in your component's template. When a user clicks on that element, it will open a form containing that field.
+
+```html
+<div data-editable="myField"></div>
+```
+
 ### Field Properties
 
 Fields can have certain properties. These are prefixed with underscores.
@@ -111,9 +119,10 @@ adName:
     permanent: true
 ```
 
+Placeholders will display when you add `data-editable="fieldName"` in your component's template. If you're using a permanent placeholder and/or you don't want the user to click through and open a form, you can specify `data-placeholder="fieldName"` instead.
+
 When deciding how to add placeholders, keep these things in mind:
 
-* Placeholders will display when you add `data-editable="fieldName"` or `data-placeholder="fieldName"` (though the latter will _not_ be clickable) to the component's template
 * You can add newlines into placeholder text, either by using yaml's [multiline strings](http://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines) or by adding `\n`, e.g. `text: ARTICLE BODY\n\nClick to add #content`
 * Placeholder height should reflect how the component will look when data is added to the field. A single line of text will be short, while a component list will probably be taller.
 * Placeholder height is a string, so you may specify different units if applicable.
@@ -138,6 +147,12 @@ _groups:
     field:
       - title
       - url
+```
+
+If you point to the group in your template, it will create a form with all of that group's fields.
+
+```html
+<div data-editable="myGroup"></div>
 ```
 
 You can add field properties to groups, which will work the same way as with fields.

--- a/services/groups.js
+++ b/services/groups.js
@@ -26,22 +26,32 @@ function expandFields(fields, data) {
 }
 
 /**
- * get only the fields with _display: settings
+  * get fields in the `settings` group
+  * Note: If you manually specify a `settings` group, it will override the default behavior
+  * This is used to guarantee field order if you need your settings in a specific order
+  * Default behavior is to look for all fields with `_display: settings` and generate
+  * a group from them (where field order is NOT enforced)
  * @param {object} data
  * @returns {array}
  */
 function getSettingsFields(data) {
+  var hasManualSettingsGroup = _.has(data, '_schema._groups.settings');
+
   if (!_.isObject(data) || _.isEmpty(data)) {
     return [];
+  } else if (hasManualSettingsGroup) {
+    // get fields in the `settings` group
+    return expandFields(_.get(data, '_schema._groups.settings.fields'), data);
+  } else {
+    // look for all fields with `_display: settings`
+    return _.reduce(data, function (fields, fieldData) {
+      if (fieldData._schema && fieldData._schema[references.displayProperty] === 'settings') {
+        fields.push(fieldData);
+      }
+
+      return fields;
+    }, []);
   }
-
-  return _.reduce(data, function (fields, fieldData) {
-    if (fieldData._schema && fieldData._schema[references.displayProperty] === 'settings') {
-      fields.push(fieldData);
-    }
-
-    return fields;
-  }, []);
 }
 
 /**

--- a/services/groups.test.js
+++ b/services/groups.test.js
@@ -92,6 +92,31 @@ describe(dirname, function () {
           bar: barData
         })).to.eql([fooData]);
       });
+
+      it('returns returns explicit settings group if specified', function () {
+        var fooData = {
+            value: 'foo',
+            _schema: { _display: 'settings' }
+          },
+          barData = {
+            value: 'bar',
+            _schema: { _display: 'settings' }
+          },
+          groupData = {
+            fields: ['bar', 'foo'], // note, order is different than the property order
+            _name: 'settings'
+          };
+
+        expect(fn({
+          foo: fooData,
+          bar: barData,
+          _schema: {
+            _groups: {
+              settings: groupData
+            }
+          }
+        })).to.eql([barData, fooData]);
+      });
     });
 
     describe('get', function () {


### PR DESCRIPTION
This allows you to specify a `settings` group manually (rather than just relying on putting `_display: settings` in a bunch of fields). It's useful when you want to guarantee the order of fields in your settings forms.

This also adds a **bunch** of documentation around behaviors and schemas, in order to clear up some functionality and better onboard new developers.