### PR TITLE
dynamic schedule stuff

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -49,8 +49,7 @@ EditorToolbar = function (el) {
 
   return state.get().then(function (res) {
     if (res.scheduled) {
-      state.toggleScheduled(true);
-      progress.open('schedule', `Page will be published ${state.formatTime(res.scheduledAt, true)}`);
+      state.openDynamicSchedule(res.scheduledAt, res.publishedUrl);
     } else if (res.published) {
       progress.open('publish', `Page is currently live: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
     }

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -99,8 +99,7 @@ module.exports = function () {
             })
             .then(function () {
               progress.done();
-              progress.open('schedule', `Publishing scheduled ` + state.formatTime(timestamp, true));
-              state.toggleScheduled(true);
+              state.openDynamicSchedule(timestamp, db.uriToUrl(pageUri));
             })
             .catch(function () {
               // note: the Error passed into this doesn't have a message, so we use a custom one

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -118,6 +118,21 @@ function formatTime(timestamp) {
   return datetime.calendar();
 }
 
+/**
+ * do something at a certain time in the future
+ * note: this is used to switch scheduled posts to published status message
+ * if the user is on the page while it's published
+ * @param {function} fn
+ * @param {Moment} date (any date that can be parsed with moment)
+ */
+function timeout(fn, date) {
+  var future = moment(date),
+    offset = future.diff(moment()).valueOf();
+
+  window.setTimeout(fn, offset);
+}
+
 module.exports.get = getPageState;
 module.exports.toggleScheduled = toggleScheduled;
 module.exports.formatTime = formatTime;
+module.exports.timeout = timeout;

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -2,7 +2,8 @@ var _ = require('lodash'),
   moment = require('moment'),
   edit = require('./edit'),
   db = require('./edit/db'),
-  dom = require('./dom');
+  dom = require('./dom'),
+  progress = require('./progress');
 
 /**
  * get canonical url from clay-meta-url component (if it exists)
@@ -132,7 +133,31 @@ function timeout(fn, date) {
   window.setTimeout(fn, offset);
 }
 
+// convenience method for dynamic schedule message
+function openDynamicSchedule(time, url) {
+  // open a schedule status message
+  progress.open('schedule', `Scheduled to publish ${formatTime(time)}`);
+  toggleScheduled(true);
+  // set it to dynamically change to publish if the page is still open
+  // (or if a new user opens the page) when it's set to publish
+  timeout(function () {
+    progress.close();
+    // close the schedule status, wait a beat (drawing the eye of the user), then open the published status
+    // Normally, transitions between status messages happen instantaneously,
+    // because they're initiated by user actions (e.g. a published page being scheduled to re-publish).
+    // Because this specific transition happens without user action (rather, it's on a timeout),
+    // we need to draw the user's eye and allow them to grasp what's going on
+    // (without being obtrusive)
+    window.setTimeout(function () {
+      progress.open('publish', `Published! <a href="${url}" target="_blank">View Page</a>`);
+      // and remember to untoggle the button
+      toggleScheduled(false);
+    }, 250);
+  }, time);
+}
+
 module.exports.get = getPageState;
 module.exports.toggleScheduled = toggleScheduled;
 module.exports.formatTime = formatTime;
 module.exports.timeout = timeout;
+module.exports.openDynamicSchedule = openDynamicSchedule;

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -94,5 +94,19 @@ describe(dirname, function () {
         expect(fn(time.valueOf())).to.equal(time.calendar());
       });
     });
+
+    describe('timeout', function () {
+      var fn = lib[this.title];
+
+      it('runs a function in the future', function (done) {
+        var time = moment().add(2, 'seconds').calendar(),
+          checkFn = function () {
+            expect(true).to.equal(true);
+            done();
+          };
+
+        fn(checkFn, time);
+      });
+    });
   });
 });


### PR DESCRIPTION
fixes #328

adds a convenience method for a dynamic schedule status message, which will turn into a published message after it's scheduled to publish

NOTE: Because this is all happening client-side, these are two edge cases which we're choosing not to cover:

* if a publish fails AFTER it has been scheduled (the server explodes, nuclear war, aliens, etc) it will still say it's published (until you refresh the page)
* the transition of the status message will happen the minute the page gets published, but it might be a few seconds off (due to servers and clients having slightly-off clocks)