### PR TITLE
dynamic schedule shows url of published page

### DIFF
--- a/services/page-state.js
+++ b/services/page-state.js
@@ -149,7 +149,7 @@ function openDynamicSchedule(time, url) {
     // we need to draw the user's eye and allow them to grasp what's going on
     // (without being obtrusive)
     window.setTimeout(function () {
-      progress.open('publish', `Published! <a href="${url}" target="_blank">View Page</a>`);
+      progress.open('publish', `Published! <a href="${url}@published.html" target="_blank">View Page</a>`);
       // and remember to untoggle the button
       toggleScheduled(false);
     }, 250);


### PR DESCRIPTION
[trello ticket](https://trello.com/c/DY7A7Au7/256-bug-viewing-published-post)

Because dynamic scheduling doesn't actually know the generated url of the page, it'll point to the page uri `@published` `.html`