### PR TITLE
fix #344

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -47,6 +47,16 @@ EditorToolbar = function (el) {
     }
   });
 
+  // close ANY open forms if user hits ESC
+  document.addEventListener('keydown', function (e) {
+    if (e.keyCode === 27) {
+      focus.unfocus();
+      // note: this will work even if there isn't a current form open
+      // fun fact: it'll unselect components as well, in case the user has a form closed
+      // but a component selected, and they don't want that
+    }
+  });
+
   return state.get().then(function (res) {
     if (res.scheduled) {
       state.openDynamicSchedule(res.scheduledAt, res.publishedUrl);


### PR DESCRIPTION
fixes #344

pressing <kbd>esc</kbd> will ALWAYS call `focus.unfocus()`, closing forms and unselecting components.

Note: if you have a form that is invalid, it will not close