### PR TITLE
add visual indicator for required behavior

### DIFF
--- a/behaviors/required.js
+++ b/behaviors/required.js
@@ -1,9 +1,20 @@
-/*
- * The literal concept of emptiness.  Later, will show when something is feeling empty.
- *
- * @module
- */
+var dom = require('../services/dom');
 
+/**
+ * Add a "required" bit of text after the label (if it exists)
+ * @param {{name: string, el: Element}} result
+ * @returns {{}}
+ */
 module.exports = function (result) {
+  var el = result.el,
+    tpl = `<span class="label-required">required</span>`,
+    requiredEl = dom.create(tpl),
+    label = dom.find(el, '.label-inner');
+
+  // only add "required" if there's a label
+  if (label) {
+    dom.insertAfter(label, requiredEl);
+  }
+
   return result;
 };

--- a/behaviors/required.scss
+++ b/behaviors/required.scss
@@ -1,0 +1,8 @@
+@import '../styleguide/colors';
+@import '../styleguide/typography';
+
+.label-required {
+  @include secondary-text();
+
+  color: $blue-50;
+}

--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -93,7 +93,7 @@
   @include label();
 
   color: $black;
-  margin-right: 10px;
+  margin-right: 8px;
   text-align: left;
 }
 


### PR DESCRIPTION
fixes #347 and [this trello ticket](https://trello.com/c/eBSb6IDu/22-required-fields-in-overlays-we-need-to-add-a-treatment-for-required-fields-that-lets-the-user-know-that-the-field-is-required)