### PR TITLE
smoothly scroll to parent

### DIFF
--- a/services/scroll.js
+++ b/services/scroll.js
@@ -1,3 +1,39 @@
+const easingEquations = {
+  easeOutSine: function (pos) {
+    return Math.sin(pos * (Math.PI / 2));
+  },
+  easeInOutSine: function (pos) {
+    return (-0.5 * (Math.cos(Math.PI * pos) - 1));
+  },
+  easeInOutQuint: function (pos) {
+    if ((pos /= 0.5) < 1) {
+      return 0.5 * Math.pow(pos, 5);
+    } else {
+      return 0.5 * (Math.pow((pos - 2), 5) + 2);
+    }
+  }
+};
+
+/**
+ * add event listeners for manual scrolling
+ * @param {function} fn to call
+ */
+function addListeners(fn) {
+  window.addEventListener('wheel', fn); // firefox
+  window.addEventListener('mousewheel', fn); // chrome, safari, etc
+  window.addEventListener('touchmove', fn); // ios, android
+}
+
+/**
+ * remove event listeners for manual scrolling
+ * @param {function} fn to remove
+ */
+function removeListeners(fn) {
+  window.removeEventListener('wheel', fn); // firefox
+  window.removeEventListener('mousewheel', fn); // chrome, safari, etc
+  window.removeEventListener('touchmove', fn); // ios, android
+}
+
 /**
  * scroll to an element
  * @param {number} scrollTargetY
@@ -5,22 +41,7 @@
  * @param {string} easing equation to use
  */
 function scrollToY(scrollTargetY, speed, easing) {
-  const scrollY = window.scrollY,
-    easingEquations = {
-      easeOutSine: function (pos) {
-        return Math.sin(pos * (Math.PI / 2));
-      },
-      easeInOutSine: function (pos) {
-        return (-0.5 * (Math.cos(Math.PI * pos) - 1));
-      },
-      easeInOutQuint: function (pos) {
-        if ((pos /= 0.5) < 1) {
-          return 0.5 * Math.pow(pos, 5);
-        } else {
-          return 0.5 * (Math.pow((pos - 2), 5) + 2);
-        }
-      }
-    };
+  const scrollY = window.scrollY;
 
   // min time .1, max time .8 seconds
   let time = Math.max(0.1, Math.min(Math.abs(scrollY - scrollTargetY) / speed, 0.8)),
@@ -33,16 +54,12 @@ function scrollToY(scrollTargetY, speed, easing) {
 
   function stopAutoScroll() {
     window.autoScroll = false;
-    window.removeEventListener('wheel', stopAutoScroll);
-    window.removeEventListener('mousewheel', stopAutoScroll);
-    window.removeEventListener('touchmove', stopAutoScroll);
+    removeListeners(stopAutoScroll);
   }
 
   // set a scroll handler so we can stop tick()'ing if the user manually scrolls
   window.autoScroll = true;
-  window.addEventListener('wheel', stopAutoScroll); // firefox
-  window.addEventListener('mousewheel', stopAutoScroll); // chrome, safari, etc
-  window.addEventListener('touchmove', stopAutoScroll); // ios, android
+  addListeners(stopAutoScroll);
 
   // recursive animation loop
   function tick() {
@@ -70,3 +87,4 @@ function scrollToY(scrollTargetY, speed, easing) {
 }
 
 module.exports.toY = scrollToY;
+module.exports.easingEquations = easingEquations;

--- a/services/scroll.js
+++ b/services/scroll.js
@@ -1,0 +1,72 @@
+/**
+ * scroll to an element
+ * @param {number} scrollTargetY
+ * @param {number} speed (in pixels per second)
+ * @param {string} easing equation to use
+ */
+function scrollToY(scrollTargetY, speed, easing) {
+  const scrollY = window.scrollY,
+    easingEquations = {
+      easeOutSine: function (pos) {
+        return Math.sin(pos * (Math.PI / 2));
+      },
+      easeInOutSine: function (pos) {
+        return (-0.5 * (Math.cos(Math.PI * pos) - 1));
+      },
+      easeInOutQuint: function (pos) {
+        if ((pos /= 0.5) < 1) {
+          return 0.5 * Math.pow(pos, 5);
+        } else {
+          return 0.5 * (Math.pow((pos - 2), 5) + 2);
+        }
+      }
+    };
+
+  // min time .1, max time .8 seconds
+  let time = Math.max(0.1, Math.min(Math.abs(scrollY - scrollTargetY) / speed, 0.8)),
+    currentTime = 0;
+
+  // defaults
+  scrollTargetY = scrollTargetY || 0;
+  speed = speed || 2000;
+  easing = easing || 'easeOutSine';
+
+  function stopAutoScroll() {
+    window.autoScroll = false;
+    window.removeEventListener('wheel', stopAutoScroll);
+    window.removeEventListener('mousewheel', stopAutoScroll);
+    window.removeEventListener('touchmove', stopAutoScroll);
+  }
+
+  // set a scroll handler so we can stop tick()'ing if the user manually scrolls
+  window.autoScroll = true;
+  window.addEventListener('wheel', stopAutoScroll); // firefox
+  window.addEventListener('mousewheel', stopAutoScroll); // chrome, safari, etc
+  window.addEventListener('touchmove', stopAutoScroll); // ios, android
+
+  // recursive animation loop
+  function tick() {
+    let p, t;
+
+    currentTime += 1 / 60;
+    p = currentTime / time;
+    t = easingEquations[easing](p);
+
+    if (p < 1 && window.autoScroll) {
+      // keep scrolling
+      window.requestAnimationFrame(tick);
+      window.scrollTo(0, scrollY + ((scrollTargetY - scrollY) * t));
+      window.autoScroll = true;
+    } else if (!window.autoScroll) {
+      // user manually stopped the scroll animation
+    } else {
+      // scroll the rest of the way to the top
+      window.scrollTo(0, scrollTargetY);
+    }
+  }
+
+  // call it once to get started
+  tick();
+}
+
+module.exports.toY = scrollToY;

--- a/services/select.js
+++ b/services/select.js
@@ -243,9 +243,23 @@ function scrollToY(scrollTargetY, speed, easing) {
   let time = Math.max(0.1, Math.min(Math.abs(scrollY - scrollTargetY) / speed, 0.8)),
     currentTime = 0;
 
+  // defaults
   scrollTargetY = scrollTargetY || 0;
   speed = speed || 2000;
   easing = easing || 'easeOutSine';
+
+  function stopAutoScroll() {
+    window.autoScroll = false;
+    window.removeEventListener('wheel', stopAutoScroll);
+    window.removeEventListener('mousewheel', stopAutoScroll);
+    window.removeEventListener('touchmove', stopAutoScroll);
+  }
+
+  // set a scroll handler so we can stop tick()'ing if the user manually scrolls
+  window.autoScroll = true;
+  window.addEventListener('wheel', stopAutoScroll); // firefox
+  window.addEventListener('mousewheel', stopAutoScroll); // chrome, safari, etc
+  window.addEventListener('touchmove', stopAutoScroll); // ios, android
 
   // recursive animation loop
   function tick() {
@@ -255,12 +269,15 @@ function scrollToY(scrollTargetY, speed, easing) {
     p = currentTime / time;
     t = easingEquations[easing](p);
 
-    if (p < 1) {
+    if (p < 1 && window.autoScroll) {
+      // keep scrolling
       window.requestAnimationFrame(tick);
-
       window.scrollTo(0, scrollY + ((scrollTargetY - scrollY) * t));
+      window.autoScroll = true;
+    } else if (!window.autoScroll) {
+      // user manually stopped the scroll animation
     } else {
-      console.log('scroll done');
+      // scroll the rest of the way to the top
       window.scrollTo(0, scrollTargetY);
     }
   }

--- a/services/select.js
+++ b/services/select.js
@@ -216,14 +216,69 @@ function addSettingsOption(componentBar, data, ref) {
 }
 
 /**
+ * scroll to an element
+ * @param {number} scrollTargetY
+ * @param {number} speed (in pixels per second)
+ * @param {string} easing equation to use
+ */
+function scrollToY(scrollTargetY, speed, easing) {
+  const scrollY = window.scrollY,
+    easingEquations = {
+      easeOutSine: function (pos) {
+        return Math.sin(pos * (Math.PI / 2));
+      },
+      easeInOutSine: function (pos) {
+        return (-0.5 * (Math.cos(Math.PI * pos) - 1));
+      },
+      easeInOutQuint: function (pos) {
+        if ((pos /= 0.5) < 1) {
+          return 0.5 * Math.pow(pos, 5);
+        } else {
+          return 0.5 * (Math.pow((pos - 2), 5) + 2);
+        }
+      }
+    };
+
+  // min time .1, max time .8 seconds
+  let time = Math.max(0.1, Math.min(Math.abs(scrollY - scrollTargetY) / speed, 0.8)),
+    currentTime = 0;
+
+  scrollTargetY = scrollTargetY || 0;
+  speed = speed || 2000;
+  easing = easing || 'easeOutSine';
+
+  // recursive animation loop
+  function tick() {
+    let p, t;
+
+    currentTime += 1 / 60;
+    p = currentTime / time;
+    t = easingEquations[easing](p);
+
+    if (p < 1) {
+      window.requestAnimationFrame(tick);
+
+      window.scrollTo(0, scrollY + ((scrollTargetY - scrollY) * t));
+    } else {
+      console.log('scroll done');
+      window.scrollTo(0, scrollTargetY);
+    }
+  }
+
+  // call it once to get started
+  tick();
+}
+
+/**
  * Scroll user to the component. "Weeee!" or "What the?"
  * @param {Element} el
  */
 function scrollToComponent(el) {
   var toolBarHeight = 70,
-    componentBarHeight = 30;
+    componentBarHeight = 30,
+    pos = window.scrollY + el.getBoundingClientRect().top - toolBarHeight - componentBarHeight;
 
-  window.scrollTo(0, window.scrollY + el.getBoundingClientRect().top - toolBarHeight - componentBarHeight);
+  scrollToY(pos, 1500, 'easeInOutQuint');
 }
 
 /**

--- a/services/select.js
+++ b/services/select.js
@@ -10,6 +10,7 @@ var _ = require('lodash'),
   groups = require('./groups'),
   site = require('./site'),
   label = require('./label'),
+  scrollToY = require('./scroll').toY,
   currentSelected;
 
 /**
@@ -213,77 +214,6 @@ function addSettingsOption(componentBar, data, ref) {
     addMenu(componentBar);
     componentBar.querySelector('.menu').appendChild(el);
   }
-}
-
-/**
- * scroll to an element
- * @param {number} scrollTargetY
- * @param {number} speed (in pixels per second)
- * @param {string} easing equation to use
- */
-function scrollToY(scrollTargetY, speed, easing) {
-  const scrollY = window.scrollY,
-    easingEquations = {
-      easeOutSine: function (pos) {
-        return Math.sin(pos * (Math.PI / 2));
-      },
-      easeInOutSine: function (pos) {
-        return (-0.5 * (Math.cos(Math.PI * pos) - 1));
-      },
-      easeInOutQuint: function (pos) {
-        if ((pos /= 0.5) < 1) {
-          return 0.5 * Math.pow(pos, 5);
-        } else {
-          return 0.5 * (Math.pow((pos - 2), 5) + 2);
-        }
-      }
-    };
-
-  // min time .1, max time .8 seconds
-  let time = Math.max(0.1, Math.min(Math.abs(scrollY - scrollTargetY) / speed, 0.8)),
-    currentTime = 0;
-
-  // defaults
-  scrollTargetY = scrollTargetY || 0;
-  speed = speed || 2000;
-  easing = easing || 'easeOutSine';
-
-  function stopAutoScroll() {
-    window.autoScroll = false;
-    window.removeEventListener('wheel', stopAutoScroll);
-    window.removeEventListener('mousewheel', stopAutoScroll);
-    window.removeEventListener('touchmove', stopAutoScroll);
-  }
-
-  // set a scroll handler so we can stop tick()'ing if the user manually scrolls
-  window.autoScroll = true;
-  window.addEventListener('wheel', stopAutoScroll); // firefox
-  window.addEventListener('mousewheel', stopAutoScroll); // chrome, safari, etc
-  window.addEventListener('touchmove', stopAutoScroll); // ios, android
-
-  // recursive animation loop
-  function tick() {
-    let p, t;
-
-    currentTime += 1 / 60;
-    p = currentTime / time;
-    t = easingEquations[easing](p);
-
-    if (p < 1 && window.autoScroll) {
-      // keep scrolling
-      window.requestAnimationFrame(tick);
-      window.scrollTo(0, scrollY + ((scrollTargetY - scrollY) * t));
-      window.autoScroll = true;
-    } else if (!window.autoScroll) {
-      // user manually stopped the scroll animation
-    } else {
-      // scroll the rest of the way to the top
-      window.scrollTo(0, scrollTargetY);
-    }
-  }
-
-  // call it once to get started
-  tick();
 }
 
 /**


### PR DESCRIPTION
fixes #348

* smoothly animates scrolling when clicking parent selector
* stops scrolling if user initiates a manual scroll (on ff, chrome, safari, ios, etc)