### PR TITLE
open component menu on hover

### DIFF
--- a/services/select.js
+++ b/services/select.js
@@ -110,10 +110,30 @@ function hideComponentList(el) {
   });
 }
 
+/**
+ * hide component menus when unselecting
+ * @param {Element} el
+ */
+function hideMenu(el) {
+  var toggle = dom.find(el, '.menu-toggle'),
+    menu = dom.find(el, '.menu');
+
+  if (toggle && menu) {
+    toggle.classList.remove('open');
+    menu.classList.remove('open');
+  }
+}
+
+/**
+ * remove selected classes on current and parent component
+ * @param {Element} [el]
+ * @param {Element} [parent]
+ */
 function removeClasses(el, parent) {
   if (el) {
     el.classList.remove('selected');
     hideComponentList(el);
+    hideMenu(el);
   }
   if (parent) {
     parent.classList.remove('selected-parent');
@@ -324,6 +344,8 @@ function addMenu(componentBar) {
     <ul class="menu"></ul>
   `);
 
+  // open menu when clicked
+  // note: on supported devices, menu will also open on hover
   el.querySelector('.menu-toggle').addEventListener('click', function (e) {
     var bar = dom.closest(e.target, '.component-bar'),
       toggle = bar.querySelector('.menu-toggle'),

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -142,22 +142,40 @@ $layout-parent-bg-color: $purple-50;
   border-bottom: none;
 }
 
+@media (any-hover: hover) {
+  .component-bar:hover > .menu-toggle {
+    border-bottom: none;
+  }
+}
+
 .component-bar > .menu {
   @include component-toolbar-layer();
 
-  display: none;
-  height: auto;
+  height: 0;
   margin: 0;
   max-width: 100%;
+  opacity: 0;
+  overflow: hidden;
   padding: 0;
   position: absolute;
   right: 0;
   top: 100%;
+  transition: opacity 200ms ease-out;
   width: auto;
 }
 
 .component-bar > .menu.open {
-  display: block;
+  height: auto;
+  opacity: 1;
+  transition: opacity 200ms ease-out;
+}
+
+@media (any-hover: hover) {
+  .component-bar:hover > .menu {
+    height: auto;
+    opacity: 1;
+    transition: opacity 200ms ease-out;
+  }
 }
 
 .component-bar .menu li {


### PR DESCRIPTION
* fixes #364
* menu will _always_ close when unselecting component
* on supported browsers (chrome, edge, _not_ firefox) hovering on the component selector will open the menu
* added quick fadein/fadeout animation to menu

_Note:_ On unsupported browsers (_firefox_), users will click to toggle the menu, as before. Same with mobile browsers.

![css4](https://cloud.githubusercontent.com/assets/447522/12591773/81cb1c9a-c437-11e5-9561-1479a793a1a1.gif)
