### PR TITLE
use watchify instead of gulp.watch for scripts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task('scripts', function () {
       cache: {},
       packageCache: {}
     }),
-    runOnce = process.argv.indexOf('--once') > -1;
+    runOnce = process.argv.indexOf('--production') > -1;
   // for non-dev environments, use `gulp scripts --once` or `gulp --once`
 
   // plugins and transforms

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,14 @@
 var gulp = require('gulp'),
-  browserify = require('gulp-browserify-globs'),
-  sourcemaps = require('gulp-sourcemaps'),
+  gutil = require('gulp-util'),
+  chalk = require('chalk'),
+  source = require('vinyl-source-stream'),
+  buffer = require('vinyl-buffer'),
+  rename = require('gulp-rename'),
+  gulpif = require('gulp-if'),
+  browserify = require('browserify'),
+  babelify = require('babelify'),
+  watchify = require('watchify'),
+  duration = require('gulp-duration'),
   uglify = require('gulp-uglify'),
   concat = require('gulp-concat'),
   sass = require('gulp-sass'),
@@ -13,19 +21,7 @@ var gulp = require('gulp'),
     'styleguide/*.css',
     'behaviors/*.scss',
     'behaviors/*.css'
-  ],
-  scriptsGlob = [
-    // used only for watching, since client.js references everything needed for browserify
-    'client.js',
-    'behaviors/*.js',
-    'behaviors/*.test.js',
-    'controllers/**',
-    'decorators/**',
-    'validators/**',
-    'services/**',
   ];
-  // sourcemaps = require('gulp-sourcemaps'),
-  // uglify = require('gulp-uglify');
 
 gulp.task('styles', function () {
   return gulp.src(stylesGlob)
@@ -37,17 +33,59 @@ gulp.task('styles', function () {
     .pipe(gulp.dest('dist'));
 });
 
+// Error reporting function
+function mapError(err) {
+  if (err.fileName) {
+    // Regular error
+    gutil.log(chalk.red(err.name)
+      + ': ' + chalk.yellow(err.fileName.replace(__dirname, ''))
+      + ': ' + 'Line ' + chalk.magenta(err.lineNumber)
+      + ' & ' + 'Column ' + chalk.magenta(err.columnNumber || err.column)
+      + ': ' + chalk.blue(err.description));
+  } else {
+    // Browserify error..
+    gutil.log(chalk.red(err.name)
+      + ': '
+      + chalk.yellow(err.message));
+  }
+}
+
 gulp.task('scripts', function () {
-  return browserify(['client.js'], {
-    debug: true,
-    transform: ['babelify'],
-    outfile: 'clay-kiln.js'
-  })
-  // load sourcemaps from browserify
-  .pipe(sourcemaps.init({ loadMaps: true }))
-  .pipe(uglify())
-  .pipe(sourcemaps.write())
-  .pipe(gulp.dest('dist'));
+  var b = browserify({
+      entries: ['./client.js'],
+      cache: {},
+      packageCache: {}
+    }),
+    runOnce = process.argv.indexOf('--once') > -1;
+  // for non-dev environments, use `gulp scripts --once` or `gulp --once`
+
+  // plugins and transforms
+  if (!runOnce) {
+    // on dev environments (by default), add watchify plugin
+    b.plugin(watchify, { ignoreWatch: ['**/node_modules/**', '**/dist/**'] });
+  }
+  b.transform(babelify, { presets: ['es2015'] });
+
+  if (!runOnce) {
+    // on dev environments (by default), re-bundle every time js changes
+    b.on('update', bundle);
+  }
+  // always kick things off with a bundle()
+  bundle();
+
+  function bundle() {
+    var bundleTimer = duration('Compile time');
+
+    console.log(chalk.blue('Compiling scripts!'));
+    b.bundle()
+      .on('error', mapError) // log bundling errors
+      .pipe(source('client.js')) // Set source name
+      .pipe(buffer()) // convert to vinyl buffer
+      .pipe(rename('clay-kiln.js')) // rename the output file
+      .pipe(gulpif(runOnce, uglify()))
+      .pipe(bundleTimer)
+      .pipe(gulp.dest('dist'));
+  }
 });
 
 // default task: run scripts and styles
@@ -57,7 +95,4 @@ gulp.task('default', ['styles', 'scripts']);
 gulp.task('watch', function () {
   // styles
   gulp.watch(stylesGlob, ['styles']);
-
-  // scripts
-  gulp.watch(scriptsGlob, ['scripts']);
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "node_modules/.bin/eslint client.js behaviors controllers services decorators validators",
     "test": "npm run lint && node_modules/.bin/karma start",
     "test-local": "npm run lint && node_modules/.bin/karma start karma.local.conf.js",
-    "postinstall": "node_modules/.bin/gulp --once"
+    "postinstall": "node_modules/.bin/gulp --production"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "node_modules/.bin/eslint client.js behaviors controllers services decorators validators",
     "test": "npm run lint && node_modules/.bin/karma start",
     "test-local": "npm run lint && node_modules/.bin/karma start karma.local.conf.js",
-    "postinstall": "node_modules/.bin/gulp"
+    "postinstall": "node_modules/.bin/gulp --once"
   },
   "repository": {
     "type": "git",
@@ -23,14 +23,12 @@
   "bugs": {
     "url": "https://github.com/nymag/clay-kiln/issues"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  },
   "homepage": "https://github.com/nymag/clay-kiln",
   "dependencies": {
+    "babel-preset-es2015": "^6.3.13",
+    "babelify": "^7.2.0",
     "browserify": "^13.0.0",
+    "chalk": "^1.1.1",
     "dollar-slice": "^2.1.0",
     "domify": "^1.3.3",
     "dragula": "^3.5.4",
@@ -38,9 +36,13 @@
     "gulp-autoprefixer": "^3.0.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",
+    "gulp-duration": "0.0.0",
+    "gulp-if": "^2.0.0",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.4.1",
+    "gulp-util": "^3.0.7",
     "he": "^0.5.0",
     "keycode": "^2.1.0",
     "lodash": "^3.8.0",
@@ -52,10 +54,10 @@
     "rivets": "^0.8.1",
     "selection-range": "^1.0.1",
     "striptags": "^2.0.2",
+    "vinyl-buffer": "^1.0.0",
     "vinyl-map2": "^1.2.1",
-    "gulp-browserify-globs": "^0.1.2",
-    "babel-preset-es2015": "^6.3.13",
-    "babelify": "^7.2.0"
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.7.0"
   },
   "devDependencies": {
     "browserify-istanbul": "^0.2.1",


### PR DESCRIPTION
* this allows browserify to cache script bundling
* decreases subsequent script compilation times (6s down to 100ms)
* pass `--once` to not compile once (with uglify)
* by default, `gulp scripts` will watch and WON'T uglify the js
* removed shoddy sourcemap support

Note: When running `npm postinstall` scripts, it'll compile once.