### PR TITLE
updated eslint for babel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,9 @@
 {
   "env": {
     "browser": true,
-    "node": true,
-    "mocha": true
+    "commonjs": true,
+    "mocha": true,
+    "es6": true,
   },
   // add global vars for chai, etc
   "globals": {
@@ -10,18 +11,25 @@
     "chai": false,
     "sinon": false
   },
-  // enable the es6 features supported by our browsers / iojs
+  // enable the es6 features supported by babel
   "ecmaFeatures": {
     "arrowFunctions": true,
     "blockBindings": true,
+    "defaultParams": true,
+    "destructuring": true,
     "forOf": true,
+    "generators": true,
+    "modules": true,
+    "objectLiteralComputedProperties": true,
     "objectLiteralDuplicateProperties": true,
-    "objectLiteralShorthandProperties": true,
     "objectLiteralShorthandMethods": true,
-    "octalLiterals": true,
-    "binaryLiterals": true,
+    "objectLiteralShorthandProperties": true,
+    "regexUFlag": true,
+    "regexYFlag": true,
+    "restParams": true,
+    "spread": true,
     "templateStrings": true,
-    "generators": true
+    "unicodeCodePointEscapes": true
   },
   "rules": {
     // possible errors


### PR DESCRIPTION
* allows much more es6 stuff
* changes `node` environment for browserify's `commonjs` environment
* allows es6 modules (transpiled by babelify)
* specifically disallows class syntax