### PR TITLE
line break fixes

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -348,7 +348,7 @@ function addStyledClass(styled) {
  * Add a line break and set the caret after it
  */
 function addLineBreak() {
-  document.execCommand('insertHTML', false, '<br><br>');
+  document.execCommand('insertHTML', false, '<br>');
 }
 
 /**

--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -348,19 +348,7 @@ function addStyledClass(styled) {
  * Add a line break and set the caret after it
  */
 function addLineBreak() {
-  var selection = window.getSelection(),
-    range = selection.getRangeAt(0),
-    br = document.createElement('br');
-
-  // woah, crazy stuff!
-  // this creates a range, inserts the <br> tag, then sets the caret after it
-  range.deleteContents();
-  range.insertNode(br);
-  range.setStartAfter(br);
-  range.setEndAfter(br);
-  range.collapse(false);
-  selection.removeAllRanges();
-  selection.addRange(range);
+  document.execCommand('insertHTML', false, '<br><br>');
 }
 
 /**

--- a/services/model-text.js
+++ b/services/model-text.js
@@ -138,14 +138,24 @@ function propertied(model, node) {
 }
 
 /**
- * Singled tags can only ever exist once at a particular position in a paragraph (<br><br> becomes <br>), and
- * they never have any content or properties.
+ * Singled tags exist at a particular position in a paragraph (rather than spanning text),
+ * and they never have any content or properties.
  *
- * They can probably be represented as an array like [1, 2, 3] that becomes "a<br>b<br>c<br>" on the text "abc", since
- * doubles can be removed by just checking for uniqueness and then sorting.
+ * @param {{text: string, blocks: object}} model
+ * @param {Node} node
  */
-function singled() {
-  // implemented later
+function singled(model, node) {
+  var pos = model.text.length,
+    nodeName = getNodeName(node),
+    tagBlockName = tagTypes[nodeName].name,
+    block = model.blocks[tagBlockName];
+
+  if (!block) {
+    block = [];
+    model.blocks[tagBlockName] = block;
+  }
+
+  block.push(pos);
 }
 
 /**
@@ -381,6 +391,43 @@ function splitTextNode(blockType, rootEl, blockAttributes, item) {
 }
 
 /**
+ * Add singled blocks to el
+ * note: singled blocks have no attributes
+ *
+ * @param {object} blockType
+ * @param {Node} rootEl
+ * @param {object} item
+ */
+function addSingledBlocks(blockType, rootEl, item) {
+  var startTextNode, blockEl, tagName,
+    textNode = item.node,
+    parentNode = textNode.parentNode || rootEl, // no parent means el is a document/document fragment
+    text = textNode.nodeValue,
+    pos = item.start,
+    startText = text.substr(0, pos),
+    endText = text.substr(pos);
+
+  // create block element
+  tagName = blockTypes[blockType].name;
+  blockEl = document.createElement(tagName);
+  // add block element
+  parentNode.insertBefore(blockEl, textNode);
+
+  // before the element
+  if (startText.length > 0) {
+    startTextNode = dom.create(startText);
+    parentNode.insertBefore(startTextNode, blockEl);
+  }
+
+  // after the element
+  if (endText.length > 0) {
+    textNode.nodeValue = endText;
+  } else {
+    parentNode.removeChild(textNode);
+  }
+}
+
+/**
  * @param {Node} el
  * @param {number} start
  * @param {number} end
@@ -495,6 +542,25 @@ function addContinuousBlocksToElement(el, model) {
 }
 
 /**
+ * @param {Node} el
+ * @param {{text: string, blocks: object}} model
+ */
+function addSingledBlocksToElement(el, model) {
+  var singledBlocks = getBlocksOfType(model.blocks, singled);
+
+  _.forOwn(singledBlocks, function (blocksOfType, blockType) {
+    var i, list, pos;
+
+    for (i = 0; i < blocksOfType.length; i++) {
+      pos = blocksOfType[i];
+      list = getTextNodeTargets(el, pos, pos); // same position
+
+      _.each(list, addSingledBlocks.bind(null, blockType, el));
+    }
+  });
+}
+
+/**
  * @param {{text: string, blocks: object}} model
  * @returns {DocumentFragment}
  */
@@ -503,6 +569,7 @@ function toElement(model) {
 
   addPropertiedBlocksToElement(el, model);
   addContinuousBlocksToElement(el, model);
+  addSingledBlocksToElement(el, model);
 
   return el;
 }

--- a/services/model-text.js
+++ b/services/model-text.js
@@ -754,6 +754,30 @@ function concatContinuousBlocks(before, after, model) {
 }
 
 /**
+ * @param {{text: string, blocks: object}} before
+ * @param {{text: string, blocks: object}} after
+ * @param {{text: string, blocks: object}} model
+ */
+function concatSingledBlocks(before, after, model) {
+  var num = before.text.length,
+    mergedBlocks = _.mapValues(_.cloneDeep(getBlocksOfType(after.blocks, singled)), function (blocks) {
+      return _.map(blocks, function (block) {
+        return block + num;
+      });
+    });
+
+  _.each(_.cloneDeep(getBlocksOfType(before.blocks, singled)), function (blocks, blockType) {
+    if (mergedBlocks[blockType]) {
+      mergedBlocks[blockType] = blocks.concat(mergedBlocks[blockType]);
+    } else {
+      mergedBlocks[blockType] = blocks;
+    }
+  });
+
+  _.assign(model.blocks, mergedBlocks);
+}
+
+/**
  * @param {object} before
  * @param {object} after
  * @returns {{text: string, blocks: object}}
@@ -766,6 +790,7 @@ function concat(before, after) {
 
   concatPropertiedBlocks(before, after, model);
   concatContinuousBlocks(before, after, model);
+  concatSingledBlocks(before, after, model);
 
   return model;
 }

--- a/services/model-text.js
+++ b/services/model-text.js
@@ -647,6 +647,38 @@ function splitContinuousBlocks(model, before, after, num) {
 }
 
 /**
+ * These cannot be split, so ones that fall on the border are removed.
+ *
+ * @param {{text: string, blocks: object}} model
+ * @param {{text: string, blocks: object}} before
+ * @param {{text: string, blocks: object}} after
+ * @param {number} num
+ */
+function splitSingledBlocks(model, before, after, num) {
+  _.each(getBlocksOfType(model.blocks, singled), function (blocks, blockType) {
+    var newPos,
+      beforeBlocks = [],
+      afterBlocks = [];
+
+    _.each(blocks, function (pos) {
+      if (pos < num) {
+        beforeBlocks.push(pos);
+      } else if (pos > num) {
+        newPos = pos - num;
+        afterBlocks.push(newPos);
+      }
+    });
+
+    if (beforeBlocks.length > 0) {
+      before.blocks[blockType] = beforeBlocks;
+    }
+    if (afterBlocks.length > 0) {
+      after.blocks[blockType] = afterBlocks;
+    }
+  });
+}
+
+/**
  * @param {{text: string, blocks: object}} model
  * @param {number} num
  * @returns {[object, object]}
@@ -663,6 +695,7 @@ function split(model, num) {
 
   splitPropertiedBlocks(model, before, after, num);
   splitContinuousBlocks(model, before, after, num);
+  splitSingledBlocks(model, before, after, num);
 
   return [before, after];
 }

--- a/services/model-text.test.js
+++ b/services/model-text.test.js
@@ -498,5 +498,16 @@ describe('model-text service', function () {
 
       expect(documentToString(lib.toElement(result))).to.deep.equal(expectedResult);
     });
+
+    it('preserves singled blocks', function () {
+      var result,
+        before = lib.fromElement(dom.create('Hello<br>th')),
+        after = lib.fromElement(dom.create('ere<br>person!')),
+        expectedResult = 'Hello<br>there<br>person!';
+
+      result = fn(before, after);
+
+      expect(documentToString(lib.toElement(result))).to.deep.equal(expectedResult);
+    });
   });
 });

--- a/services/model-text.test.js
+++ b/services/model-text.test.js
@@ -125,6 +125,26 @@ describe('model-text service', function () {
       expect(fn(el)).to.deep.equal(result);
     });
 
+    it('finds singled blocks (i.e., line breaks)', function () {
+      var el = dom.create('Hello<br>there<br />person!'),
+        result = {
+          text: 'Hellothereperson!',
+          blocks: { 'soft return': [5, 10] }
+        };
+
+      expect(fn(el)).to.deep.equal(result);
+    });
+
+    it('allows multiple singled blocks (i.e., <br><br>)', function () {
+      var el = dom.create('Hello<br><br />there person!'),
+        result = {
+          text: 'Hellothere person!',
+          blocks: { 'soft return': [5, 5] }
+        };
+
+      expect(fn(el)).to.deep.equal(result);
+    });
+
     it('does not merge propertied blocks (i.e., links in links)', function () {
       var el = dom.create('Hello <a href="outer place">there <a href="place" alt="hey">person</a> over there</a>!'),
         result = {
@@ -264,6 +284,36 @@ describe('model-text service', function () {
           blocks: {strong: [0, 12], link: [{start: 6, end: 18}]}
         },
         result = '<strong>Hello </strong><a><strong>there </strong>person</a>!';
+
+      expect(documentToString(fn(model))).to.equal(result);
+    });
+
+    it('converts singled blocks', function () {
+      var model = {
+          text: 'Hellothereperson!',
+          blocks: {'soft return': [5, 10]}
+        },
+        result = 'Hello<br>there<br>person!';
+
+      expect(documentToString(fn(model))).to.equal(result);
+    });
+
+    it('overlaps when continuous blocks applied to singled blocks', function () {
+      var model = {
+          text: 'Hellothere person!',
+          blocks: {strong: [0, 11], 'soft return': [5]}
+        },
+        result = '<strong>Hello<br>there </strong>person!';
+
+      expect(documentToString(fn(model))).to.equal(result);
+    });
+
+    it('overlaps when propertied blocks applied to singled blocks', function () {
+      var model = {
+          text: 'Hellothere person!',
+          blocks: {link: [{start: 2, end: 10}], 'soft return': [5]}
+        },
+        result = 'He<a>llo<br>there</a> person!';
 
       expect(documentToString(fn(model))).to.equal(result);
     });

--- a/services/model-text.test.js
+++ b/services/model-text.test.js
@@ -419,6 +419,48 @@ describe('model-text service', function () {
       });
       expect(result).to.deep.equal(expectedResult);
     });
+
+    it('splits singled blocks to each side', function () {
+      var num = 7,
+        el = dom.create('Hello<br>there<br>person!'),
+        result,
+        expectedResult = ['Hello<br>th', 'ere<br>person!'];
+
+      result = fn(lib.fromElement(el), num);
+
+      result = _.map(result, function (modelResult) {
+        return documentToString(lib.toElement(modelResult));
+      });
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    it('removes singled blocks at middle', function () {
+      var num = 8,
+        el = dom.create('Hello th<br>ere person!'),
+        result,
+        expectedResult = ['Hello th', 'ere person!'];
+
+      result = fn(lib.fromElement(el), num);
+
+      result = _.map(result, function (modelResult) {
+        return documentToString(lib.toElement(modelResult));
+      });
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    it('removes multiple singled blocks at middle', function () {
+      var num = 8,
+        el = dom.create('Hello th<br><br />ere person!'),
+        result,
+        expectedResult = ['Hello th', 'ere person!'];
+
+      result = fn(lib.fromElement(el), num);
+
+      result = _.map(result, function (modelResult) {
+        return documentToString(lib.toElement(modelResult));
+      });
+      expect(result).to.deep.equal(expectedResult);
+    });
   });
 
   describe('concat', function () {


### PR DESCRIPTION
* better creation of line breaks when you press <kbd>shift + enter</kbd>
* added ability for model-text to handle line breaks when parsing
* this allows you to paste stuff without all the line breaks disappearing