### PR TITLE
Publish layouts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,7 @@
     "vars-on-top": 2,
     "wrap-iife": 2,
     // strict mode
-    "strict": [2, "safe"],
+    "strict": [2, "never"],
     // variables
     "no-unused-vars": 2,
     // node.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,29 +11,22 @@
     "chai": false,
     "sinon": false
   },
-  // enable the es6 features supported by babel
+  // enable the es6 features supported by our browsers / iojs
   "ecmaFeatures": {
     "arrowFunctions": true,
     "blockBindings": true,
-    "defaultParams": true,
-    "destructuring": true,
     "forOf": true,
-    "generators": true,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
     "objectLiteralDuplicateProperties": true,
-    "objectLiteralShorthandMethods": true,
     "objectLiteralShorthandProperties": true,
-    "regexUFlag": true,
-    "regexYFlag": true,
-    "restParams": true,
-    "spread": true,
+    "objectLiteralShorthandMethods": true,
+    "octalLiterals": true,
+    "binaryLiterals": true,
     "templateStrings": true,
-    "unicodeCodePointEscapes": true
+    "generators": true
   },
   "rules": {
     // possible errors
-    "no-extra-parens": [1,"functions"],
+    "no-extra-parens": 1,
     "valid-jsdoc": [1, {
       "requireReturn": false,
       "requireParamDescription": false,
@@ -48,10 +41,11 @@
     "no-self-compare": 2,
     "no-throw-literal": 2,
     "no-void": 2,
+    "quote-props": [2, "as-needed"],
     "vars-on-top": 2,
     "wrap-iife": 2,
     // strict mode
-    "strict": [2, "never"],
+    "strict": [2, "safe"],
     // variables
     "no-unused-vars": 2,
     // node.js
@@ -62,7 +56,7 @@
     // stylistic issues
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
     "comma-style": [2, "last"],
-    "indent": [2, 2, { "SwitchCase": 1 ,"VariableDeclarator": 1}],
+    "indent": [2, 2, { "SwitchCase": 1 }],
     "max-nested-callbacks": [2, 4],
     "newline-after-var": [2, "always"],
     "no-nested-ternary": 2,
@@ -73,7 +67,7 @@
     "one-var": 2,
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "always"],
-    "space-after-keywords": [2, "always"],
+    "keyword-spacing": 2,
     "space-before-blocks": [2, "always"],
     "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
     "space-infix-ops": [1, {"int32Hint": false}],

--- a/behaviors/label.test.js
+++ b/behaviors/label.test.js
@@ -17,7 +17,7 @@ describe(dirname, function () {
       var result, innerLabel;
 
       // Add an outer label.
-      fixture.el.appendChild(dom.create(`<label class="input-label"><input></label>`));
+      fixture.el.appendChild(dom.create('<label class="input-label"><input></label>'));
       result = lib(fixture);
       innerLabel = result.el.querySelector('.input-label').firstElementChild;
       expect(innerLabel.className).to.eql('label-inner');

--- a/behaviors/radio.test.js
+++ b/behaviors/radio.test.js
@@ -11,7 +11,7 @@ describe(dirname, function () {
 
     it('replaces the result.el', function () { // We could call this a "root" behavior
       var result,
-        elBefore = dom.create(`<div class="el-before"></div>`);
+        elBefore = dom.create('<div class="el-before"></div>');
 
       fixture.el = elBefore;
       result = lib(fixture, {options: options});

--- a/behaviors/required.js
+++ b/behaviors/required.js
@@ -7,7 +7,7 @@ var dom = require('../services/dom');
  */
 module.exports = function (result) {
   var el = result.el,
-    tpl = `<span class="label-required">required</span>`,
+    tpl = '<span class="label-required">required</span>',
     requiredEl = dom.create(tpl),
     label = dom.find(el, '.label-inner');
 

--- a/behaviors/segmented-button.test.js
+++ b/behaviors/segmented-button.test.js
@@ -15,7 +15,7 @@ describe(dirname, function () {
 
     it('replaces the result.el', function () { // We could call this a "root" behavior
       var result,
-        elBefore = dom.create(`<div class="el-before"></div>`);
+        elBefore = dom.create('<div class="el-before"></div>');
 
       fixture.el = elBefore;
       result = lib(fixture, {options: options});

--- a/behaviors/select.test.js
+++ b/behaviors/select.test.js
@@ -11,7 +11,7 @@ describe(dirname, function () {
 
     it('replaces the result.el', function () { // We could call this a "root" behavior
       var result,
-        elBefore = dom.create(`<div class="el-before"></div>`);
+        elBefore = dom.create('<div class="el-before"></div>');
 
       fixture.el = elBefore;
       result = lib(fixture, {options: options});

--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -193,7 +193,7 @@ module.exports = function (result, args) {
       function handleItemKeyEvents(e) {
         var key = keycode(e);
 
-        if (key === 'enter' || key === 'tab' || (key === ',' && e.shiftKey === false)) {
+        if (key === 'enter' || key === 'tab' || key === ',' && e.shiftKey === false) {
           addItem(e);
         } else if (key === 'delete' || key === 'backspace' || key === 'left') {
           selectLastItem(e);

--- a/behaviors/soft-maxlength.test.js
+++ b/behaviors/soft-maxlength.test.js
@@ -28,7 +28,7 @@ describe(dirname, function () {
     it('has binder that toggles too-long classes', function () {
       var result, input, span, binder;
 
-      fixture.el = dom.create(`<div><input></div>`);
+      fixture.el = dom.create('<div><input></div>');
       result = lib(fixture, args);
       input = result.el.querySelector('input');
       span = result.el.querySelector('span.soft-maxlength');
@@ -49,7 +49,7 @@ describe(dirname, function () {
     it('has binder that allows for undefined field', function () {
       var result, input, span, binder;
 
-      fixture.el = dom.create(`<div><input></div>`);
+      fixture.el = dom.create('<div><input></div>');
       result = lib(fixture, args);
       input = result.el.querySelector('input');
       span = result.el.querySelector('span.soft-maxlength');

--- a/behaviors/text.test.js
+++ b/behaviors/text.test.js
@@ -26,7 +26,7 @@ describe(dirname, function () {
 
     it('replaces the result.el', function () { // We could call this a "root" behavior
       var result,
-        elBefore = dom.create(`<div class="el-before"></div>`);
+        elBefore = dom.create('<div class="el-before"></div>');
 
       fixture.el = elBefore;
       result = lib(fixture, {});

--- a/behaviors/textarea.test.js
+++ b/behaviors/textarea.test.js
@@ -14,7 +14,7 @@ describe(dirname, function () {
 
     it('replaces the result.el', function () { // We could call this a "root" behavior
       var result,
-        elBefore = dom.create(`<div class="el-before"></div>`);
+        elBefore = dom.create('<div class="el-before"></div>');
 
       fixture.el = elBefore;
       result = lib(fixture, args);

--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -96,7 +96,7 @@ EditorToolbar.prototype = {
       .then(pane.openPublish)
       .catch(function () {
         progress.done('error');
-        progress.open('error', `Data could not be saved. Please review your open form.`, true);
+        progress.open('error', 'Data could not be saved. Please review your open form.', true);
       });
   }
 };

--- a/controllers/overlay.js
+++ b/controllers/overlay.js
@@ -37,7 +37,7 @@ module.exports = function () {
 
   constructor.prototype = {
     events: {
-      'click': 'close'
+      click: 'close'
     },
 
     close: function (e) {

--- a/controllers/pane.js
+++ b/controllers/pane.js
@@ -36,7 +36,7 @@ module.exports = function () {
 
   constructor.prototype = {
     events: {
-      'click': 'close',
+      click: 'close',
       '.close click': 'close'
     },
 

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -81,7 +81,7 @@ module.exports = function () {
               .catch(function () {
                 // note: the Error passed into this doesn't have a message, so we use a custom one
                 progress.done('error');
-                progress.open('error', `Server errored when publishing, please try again.`, true);
+                progress.open('error', 'Server errored when publishing, please try again.', true);
               });
           });
         }
@@ -104,7 +104,7 @@ module.exports = function () {
         .catch(function () {
           // note: the Error passed into this doesn't have a message, so we use a custom one
           progress.done('error');
-          progress.open('error', `Server errored when unpublishing, please try again.`, true);
+          progress.open('error', 'Server errored when unpublishing, please try again.', true);
         });
     },
 
@@ -140,7 +140,7 @@ module.exports = function () {
               .catch(function () {
                 // note: the Error passed into this doesn't have a message, so we use a custom one
                 progress.done('error');
-                progress.open('error', `Server errored when scheduling, please try again.`, true);
+                progress.open('error', 'Server errored when scheduling, please try again.', true);
               });
           });
         }
@@ -154,13 +154,13 @@ module.exports = function () {
       return unschedulePageAndLayout()
         .then(function () {
           progress.done();
-          progress.open('schedule', `Unscheduled!`, true);
+          progress.open('schedule', 'Unscheduled!', true);
           state.toggleScheduled(false);
         })
         .catch(function () {
           // note: the Error passed into this doesn't have a message, so we use a custom one
           progress.done('error');
-          progress.open('error', `Server errored when unscheduling, please try again.`, true);
+          progress.open('error', 'Server errored when unscheduling, please try again.', true);
         });
     }
   };

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -34,7 +34,8 @@ module.exports = function () {
           pane.openValidationErrors(errors);
         } else {
           return edit.unschedulePublish(pageUri).then(function () {
-            return edit.publishPage()
+            return edit.publishLayout()
+              .then(edit.publishPage) // this returns the published page url
               .then(function (url) {
                 progress.done();
                 progress.open('publish', `Published! <a href="${url}" target="_blank">View Page</a>`);

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -34,9 +34,10 @@ module.exports = function () {
           pane.openValidationErrors(errors);
         } else {
           return edit.unschedulePublish(pageUri).then(function () {
-            return edit.publishLayout()
-              .then(edit.publishPage) // this returns the published page url
-              .then(function (url) {
+            return Promise.all([edit.publishPage(), edit.publishLayout()])
+              .then(function (promises) {
+                var url = promises[0];
+
                 progress.done();
                 progress.open('publish', `Published! <a href="${url}" target="_blank">View Page</a>`);
                 state.toggleScheduled(false);

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chai": "^3.4.1",
     "chai-things": "^0.2.0",
     "coveralls": "^2.11.2",
-    "eslint": "^1.1.0",
+    "eslint": "^2.2.0",
     "karma": "^0.13.15",
     "karma-browserify": "^5.0.1",
     "karma-browserstack-launcher": "^0.1.2",

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -174,17 +174,21 @@ function publishPage() {
 }
 
 /**
+ * get layout uri for current page
+ * @returns {Promise}
+ */
+function getLayout() {
+  return cache.getDataOnly(dom.pageUri()).then(data => data.layout);
+}
+
+/**
  * Publish current page's layout.
  *
  * @returns {Promise.string}
  */
 function publishLayout() {
-  var pageUri = dom.pageUri();
-
-  return cache.getDataOnly(pageUri).then(function (pageData) {
-    var layoutUri = pageData.layout;
-
-    return db.save(layoutUri + '@published'); // PUT @published with empty data
+  return getLayout().then(function (layout) {
+    return db.save(layout + '@published'); // PUT @published with empty data
   });
 }
 
@@ -368,7 +372,7 @@ function addToParentList(opts) {
  * schedule publish
  * @param {object} data
  * @param {number} data.at unix timestamp to be published at
- * @param {string} data.publish uri to be published
+ * @param {string} data.publish url to be published
  * @returns {Promise}
  */
 function schedulePublish(data) {
@@ -424,6 +428,7 @@ module.exports = {
   createComponent: createComponent,
   createPage: createPage,
   publishPage: publishPage,
+  getLayout: getLayout,
   publishLayout: publishLayout,
   unpublishPage: unpublishPage,
   removeFromParentList: removeFromParentList,

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -111,7 +111,7 @@ function save(data) {
         })
         .catch(function () {
           progress.done('error');
-          progress.open('error', `A server error occured. Please try again.`, true);
+          progress.open('error', 'A server error occured. Please try again.', true);
         });
     }
   });

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -174,6 +174,21 @@ function publishPage() {
 }
 
 /**
+ * Publish current page's layout.
+ *
+ * @returns {Promise.string}
+ */
+function publishLayout() {
+  var pageUri = dom.pageUri();
+
+  return cache.getDataOnly(pageUri).then(function (pageData) {
+    var layoutUri = pageData.layout;
+
+    return db.save(layoutUri + '@published'); // PUT @published with empty data
+  });
+}
+
+/**
  * unpublishes current page. returns the deleted uri
  * @returns {Promise}
  */
@@ -409,6 +424,7 @@ module.exports = {
   createComponent: createComponent,
   createPage: createPage,
   publishPage: publishPage,
+  publishLayout: publishLayout,
   unpublishPage: unpublishPage,
   removeFromParentList: removeFromParentList,
   removeUri: removeUri,

--- a/services/model-text.js
+++ b/services/model-text.js
@@ -28,7 +28,7 @@ function contentTextOnly(node) {
 function knownTagsOnly(node) {
   var name = node.nodeName;
 
-  return !!tagTypes[name] || (node.nodeType === Node.TEXT_NODE && contentTextOnly(node));
+  return !!tagTypes[name] || node.nodeType === Node.TEXT_NODE && contentTextOnly(node);
 }
 
 /**
@@ -220,15 +220,15 @@ blockTypes = _.transform(tagTypes, function (obj, tag, name) {
  * @enum
  */
 sameAs = {
-  'B': 'STRONG',
-  'U': 'EM',
-  'I': 'EM',
-  'H1': 'H2',
-  'H3': 'H2',
-  'H4': 'H2',
-  'H5': 'H2',
-  'H6': 'H2',
-  'STRIKE': 'DEL'
+  B: 'STRONG',
+  U: 'EM',
+  I: 'EM',
+  H1: 'H2',
+  H3: 'H2',
+  H4: 'H2',
+  H5: 'H2',
+  H6: 'H2',
+  STRIKE: 'DEL'
 };
 
 /**

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -40,7 +40,13 @@ function getPageUrl(pageData) {
     throw new Error('Page has no url!');
   }
 
-  return db.getHead(db.urlToUri(url)).then(() => url);
+  return db.getHead(db.urlToUri(url)).then(function (res) {
+    if (res) {
+      return url;
+    } else {
+      throw new Error('Url isn\'t a real page!');
+    }
+  });
 }
 
 function isArticleReference(ref) {

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -1,4 +1,3 @@
-'use strict';
 const _ = require('lodash'),
   moment = require('moment'),
   edit = require('./edit'),

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -75,7 +75,7 @@ describe(dirname, function () {
 
     describe('toggleScheduled', function () {
       var fn = lib[this.title],
-        button = dom.create(`<div class="kiln-toolbar-inner"><button class="publish">Publish</button></div>`);
+        button = dom.create('<div class="kiln-toolbar-inner"><button class="publish">Publish</button></div>');
 
       before(function () {
         document.body.appendChild(button);

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -29,8 +29,13 @@ describe(dirname, function () {
         publishedRef = fakePageUri + '@published',
         fakeUrl = 'http://domain.com/page.html',
         fakeUri = db.urlToUri(fakeUrl),
+        fakeArticleRef = 'domain.com/components/article/instances/fake',
+        fakeArticle = {
+          date: new Date(0)
+        },
         fakeInstanceData = {
-          url: fakeUrl
+          url: fakeUrl,
+          main: fakeArticleRef
         };
 
       function expectState(expectedState) {
@@ -39,30 +44,32 @@ describe(dirname, function () {
         };
       }
 
-      it('gets scheduled state (published url is null if not published)', function () {
+      it('gets scheduled when not published', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
         getDataOnly.withArgs(publishedRef).returns(Promise.reject());
-        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: false, publishedUrl: null }));
+        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: false, publishedUrl: null, publishedAt: null }));
       });
 
-      it('gets published state (and published url)', function () {
+      it('gets published when not scheduled', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
         getDataOnly.withArgs(publishedRef).returns(Promise.resolve(fakeInstanceData));
+        getDataOnly.withArgs(fakeArticleRef).returns(Promise.resolve(fakeArticle));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
-        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: true, publishedUrl: fakeUrl }));
+        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: true, publishedUrl: fakeUrl, publishedAt: new Date(0) }));
       });
 
-      it('gets scheduled and published state (and published url)', function () {
+      it('gets scheduled and published', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
         getDataOnly.withArgs(publishedRef).returns(Promise.resolve(fakeInstanceData));
+        getDataOnly.withArgs(fakeArticleRef).returns(Promise.resolve(fakeArticle));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
-        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: true, publishedUrl: fakeUrl }));
+        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: true, publishedUrl: fakeUrl, publishedAt: new Date(0) }));
       });
 
-      it('gets neither state', function () {
+      it('gets neither scheduled nor published', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
         getDataOnly.withArgs(publishedRef).returns(Promise.reject());
-        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: false, publishedUrl: null }));
+        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: false, publishedUrl: null, publishedAt: null }));
       });
     });
 

--- a/services/pane.js
+++ b/services/pane.js
@@ -1,3 +1,4 @@
+'use strict';
 var _ = require('lodash'),
   moment = require('moment'),
   dom = require('./dom'),
@@ -64,7 +65,7 @@ function openPublish() {
   var header = 'Schedule Publish',
     today = moment().format('YYYY-MM-DD'),
     now = moment().format('HH:mm'),
-    actions = dom.create(`<div class="actions"></div>`),
+    actions = dom.create('<div class="actions"></div>'),
     schedule = dom.create(`<form class="schedule">
       <label class="schedule-label" for="schedule-date">Date</label>
       <input id="schedule-date" class="schedule-input" type="date" min="${today}" value="${today}" placeholder="${today}"></input>
@@ -72,9 +73,9 @@ function openPublish() {
       <input id="schedule-time" class="schedule-input" type="time" value="${now}" placeholder="${now}"></input>
       <button class="schedule-publish">Schedule Publish</button>
     </form>`),
-    unschedule = dom.create(`<button class="unschedule">Unschedule</button>`),
-    publishNow = dom.create(`<button class="publish-now">Publish Now</button>`),
-    unpublish = dom.create(`<button class="unpublish">Unpublish</button>`),
+    unschedule = dom.create('<button class="unschedule">Unschedule</button>'),
+    publishNow = dom.create('<button class="publish-now">Publish Now</button>'),
+    unpublish = dom.create('<button class="unpublish">Unpublish Page</button>'),
     el;
 
   return state.get().then(function (res) {

--- a/services/pane.js
+++ b/services/pane.js
@@ -77,7 +77,7 @@ function createPublishMessages(res) {
 
   if (res.scheduled) {
     // scheduled message
-    messages.appendChild(dom.create(`<p>This is scheduled to publish ${state.formatTime(res.scheduledAt)}.</p>`));
+    messages.appendChild(dom.create(`<p>Scheduled to publish ${state.formatTime(res.scheduledAt)}.</p>`));
   }
 
   // message about what publishing affects

--- a/services/pane.js
+++ b/services/pane.js
@@ -1,4 +1,3 @@
-'use strict';
 var _ = require('lodash'),
   moment = require('moment'),
   dom = require('./dom'),

--- a/services/scroll.js
+++ b/services/scroll.js
@@ -3,13 +3,13 @@ const easingEquations = {
     return Math.sin(pos * (Math.PI / 2));
   },
   easeInOutSine: function (pos) {
-    return (-0.5 * (Math.cos(Math.PI * pos) - 1));
+    return -0.5 * (Math.cos(Math.PI * pos) - 1);
   },
   easeInOutQuint: function (pos) {
     if ((pos /= 0.5) < 1) {
       return 0.5 * Math.pow(pos, 5);
     } else {
-      return 0.5 * (Math.pow((pos - 2), 5) + 2);
+      return 0.5 * (Math.pow(pos - 2, 5) + 2);
     }
   }
 };
@@ -72,7 +72,7 @@ function scrollToY(scrollTargetY, speed, easing) {
     if (p < 1 && window.autoScroll) {
       // keep scrolling
       window.requestAnimationFrame(tick);
-      window.scrollTo(0, scrollY + ((scrollTargetY - scrollY) * t));
+      window.scrollTo(0, scrollY + (scrollTargetY - scrollY) * t);
       window.autoScroll = true;
     } else if (!window.autoScroll) {
       // user manually stopped the scroll animation

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -95,6 +95,13 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
 
 /* publish */
 
+.kiln-toolbar-pane .messages {
+  p {
+    margin: 0 0 10px;
+    color: $black-50;
+  }
+}
+
 .kiln-toolbar-pane .actions,
 .kiln-toolbar-pane .schedule {
   @include clearfix();


### PR DESCRIPTION
* <kbd>publish now</kbd> publishes page and layout
* <kbd>schedule publish</kbd> schedules publishing of page and layout
* <kbd>unschedule</kbd> unschedules page _and_ layout publishing (note to keep in mind: if you schedule a layout publish, then unschedule on a different page that's also scheduled, the layout will be unscheduled)
* <kbd>unpublish</kbd> will only make the _page_ private. it will not revert any layout changes

Changelog

* added pub/schedule/unschedule functionality
* added messaging to publish pane
* NOTE: non-article pages _won't_ display as published anymore (so you won't get the status message or be able to unpublish them). This is due to us checking the article date in page-status. In the _near_ future we'll have proper timestamps to work with and this will work again