### PR TITLE
dynamic placeholder heights

### DIFF
--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -23,13 +23,20 @@ function getPlaceholderText(path, schema) {
 
 /**
  * get placeholder height
+ * @param {Element} parent
  * @param  {object} schema
  * @return {string}
  */
-function getPlaceholderHeight(schema) {
-  var placeholder = schema[references.placeholderProperty];
+function getPlaceholderHeight(parent, schema) {
+  var placeholder = schema[references.placeholderProperty],
+    placeholderHeight = placeholder && parseInt(placeholder.height, 10) || 100, // defaults to 100px
+    parentHeight = parent && parseInt(getComputedStyle(parent).height);
 
-  return placeholder && placeholder.height || '100px';
+  if (parentHeight && parentHeight > placeholderHeight) {
+    return parentHeight + 'px';
+  } else {
+    return placeholderHeight + 'px';
+  }
 }
 
 /**
@@ -180,7 +187,7 @@ function addPlaceholder(el, options) {
 
   return addPlaceholderDom(el, {
     text: getPlaceholderText(path, schema),
-    height: getPlaceholderHeight(schema),
+    height: getPlaceholderHeight(el, schema),
     permanent: getPlaceholderPermanence(schema)
   });
 }

--- a/decorators/placeholder.test.js
+++ b/decorators/placeholder.test.js
@@ -41,17 +41,21 @@ describe(dirname, function () {
       var fn = lib[this.title];
 
       it('gets height when set explicitly', function () {
-        expect(fn({_placeholder: {height: '500px'}})).to.equal('500px');
+        expect(fn(document.createElement('div'), {_placeholder: {height: '500px'}})).to.equal('500px');
       });
 
-      it('gets auto height when set explicitly', function () {
-        expect(fn({_placeholder: {height: 'auto'}})).to.equal('auto');
+      it('uses computed parent height if greater than set height', function () {
+        var el = document.createElement('div');
+
+        el.style.minHeight = '100px';
+        document.body.appendChild(el); // append to dom so getComputedStyle works
+        expect(fn(el, {_placeholder: {height: '10px'}})).to.equal('100px');
       });
 
       it('falls back to 100px height', function () {
-        expect(fn({_placeholder: {text: 'This is some text'}})).to.equal('100px');
-        expect(fn({_placeholder: true})).to.equal('100px');
-        expect(fn({_placeholder: 'true'})).to.equal('100px');
+        expect(fn(document.createElement('div'), {_placeholder: {text: 'This is some text'}})).to.equal('100px');
+        expect(fn(document.createElement('div'), {_placeholder: true})).to.equal('100px');
+        expect(fn(document.createElement('div'), {_placeholder: 'true'})).to.equal('100px');
       });
     });
 


### PR DESCRIPTION
* uses declared placeholder height, falls back to 100px (as before)
* if parent component has a set height (and that height is larger than the declared placeholder height), placeholder will fill vertical space
* this makes ads (and other components where instances may have different explicitly-set heights) look really nice in edit mode :sparkles: 