### PR TITLE
add  argument to component-ref

### DIFF
--- a/behaviors/component-ref.js
+++ b/behaviors/component-ref.js
@@ -3,6 +3,55 @@ var _ = require('lodash'),
   references = require('../services/references');
 
 /**
+ * find components with matching selector
+ * note: this gives users a lot of flexibility, but 99% of the time you want to search on the name
+ * @param {string} selector
+ * @returns {array} array of uris
+ */
+function findElementsWithSelector(selector) {
+  return _.map(document.querySelectorAll(selector), function (el) {
+    return el.getAttribute(references.referenceAttribute);
+  });
+}
+
+function selectorFromName(name) {
+  return '[data-uri*="/components/' + name + '/"]';
+}
+
+function componentWithName(name) {
+  return '/components/' + name + '/';
+}
+
+function getUriFromComment(str) {
+  var match = str.match(/data-uri="(.*?)"/);
+
+  return match && match[1];
+}
+
+/**
+ * find components with matching name
+ * @param {string} name
+ * @returns {array} array of uris
+ */
+function findElementsWithName(name) {
+  return findElementsWithSelector(selectorFromName(name));
+}
+
+function findCommentsWithName(name) {
+  var matches = [],
+    walker = document.createTreeWalker(document.head, NodeFilter.SHOW_COMMENT),
+    node;
+
+  while (node = walker.nextNode()) {
+    if (_.contains(node.data, componentWithName(name)) && getUriFromComment(node.data)) {
+      matches.push(getUriFromComment(node.data));
+    }
+  }
+
+  return matches;
+}
+
+/**
  * Append hidden field to enable component instances to affect other component instances
  * e.g. article affecting the page title
  * @param {{name: string, bindings: {}, el: Element}} result
@@ -14,11 +63,12 @@ module.exports = function (result, args) {
     name = result.name;
 
   if (args.selector) {
-    result.bindings.data.value = _.map(document.querySelectorAll(args.selector), function (el) {
-      return el.getAttribute(references.referenceAttribute);
-    });
-    hiddenInput = dom.create(`<input type="hidden" class="input-text" rv-field="${name}" rv-value="${name}.data.value">`);
-    result.el.appendChild(hiddenInput);
+    result.bindings.data.value = findElementsWithSelector(args.selector);
+  } else if (args.name) {
+    result.bindings.data.value = findElementsWithName(args.name).concat(findCommentsWithName(args.name));
   }
+
+  hiddenInput = dom.create(`<input type="hidden" class="input-text" rv-field="${name}" rv-value="${name}.data.value">`);
+  result.el.appendChild(hiddenInput);
   return result;
 };

--- a/behaviors/component-ref.test.js
+++ b/behaviors/component-ref.test.js
@@ -1,4 +1,5 @@
-var dirname = __dirname.split('/').pop(),
+var _ = require('lodash'),
+  dirname = __dirname.split('/').pop(),
   filename = __filename.split('/').pop().split('.').shift(),
   fixture = require('../test/fixtures/behavior')({}),
   dom = require('../services/dom'),
@@ -7,14 +8,19 @@ var dirname = __dirname.split('/').pop(),
 describe(dirname, function () {
   describe(filename, function () {
     var querySelectorClass = 'query-selector',
-      anotherComponent = dom.create('<div class="' + querySelectorClass + '" data-uri="site.com/path/components/x/instances/0"></div>');
+      anotherComponentUri = 'site.com/path/components/x/instances/0',
+      anotherComponent = dom.create('<div class="' + querySelectorClass + '" data-uri="' + anotherComponentUri + '"></div>'),
+      commentUri = 'site.com/path/components/y/instances/0',
+      comment = document.createComment(' data-uri="' + commentUri + '"');
 
     beforeEach(function () {
       document.body.appendChild(anotherComponent);
+      document.head.appendChild(comment);
     });
 
     afterEach(function () {
       document.body.removeChild(anotherComponent);
+      document.head.removeChild(comment);
     });
 
     it('appends a hidden field', function () {
@@ -23,9 +29,24 @@ describe(dirname, function () {
 
       expect(input.tagName).to.eql('INPUT');
       expect(input.type).to.eql('hidden');
-      expect(input.getAttribute('rv-field')).to.eql('foo');
-      expect(input.getAttribute('rv-value')).to.eql('foo.data.value');
     });
 
+    it('finds component element with selector', function () {
+      var result = lib(fixture, {selector: '[data-uri*="/components/x/"]'});
+
+      expect(_.get(result, 'bindings.data.value')).to.deep.equal([anotherComponentUri]);
+    });
+
+    it('finds component element with name', function () {
+      var result = lib(fixture, {name: 'x'});
+
+      expect(_.get(result, 'bindings.data.value')).to.deep.equal([anotherComponentUri]);
+    });
+
+    it('finds component comment (in head) with name', function () {
+      var result = lib(fixture, {name: 'y'});
+
+      expect(_.get(result, 'bindings.data.value')).to.deep.equal([commentUri]);
+    });
   });
 });


### PR DESCRIPTION
this works for both elements (anywhere on the page) and comments (just in the head, since we have to walk through them). It's extremely useful when targetting `<meta>` components.

fixes #394