### PR TITLE
added rollupify

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,8 @@
 {
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 6
+  },
   "env": {
     "browser": true,
     "commonjs": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,8 @@
     "octalLiterals": true,
     "binaryLiterals": true,
     "templateStrings": true,
-    "generators": true
+    "generators": true,
+    "modules": true
   },
   "rules": {
     // possible errors

--- a/behaviors/autocomplete.js
+++ b/behaviors/autocomplete.js
@@ -2,9 +2,10 @@ var dom = require('../services/dom'),
   db = require('../services/edit/db'),
   _ = require('lodash'),
   site = require('../services/site'),
-  cid = require('../services/cid'),
   getInput = require('../services/get-input'),
   textProp = 'text';
+
+import cid from '../services/cid';
 
 /**
  *

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var gulp = require('gulp'),
   rename = require('gulp-rename'),
   // gulpif = require('gulp-if'),
   browserify = require('browserify'),
+  rollupify = require('rollupify'),
   babelify = require('babelify'),
   es2015 = require('babel-preset-es2015'),
   watchify = require('watchify'),
@@ -65,6 +66,7 @@ gulp.task('scripts', function () {
     // on dev environments (by default), add watchify plugin
     b.plugin(watchify, { ignoreWatch: ['**/node_modules/**', '**/dist/**'] });
   }
+  b.transform(rollupify);
   b.transform(babelify, { presets: [es2015] });
 
   if (!runOnce) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,13 +16,16 @@ settings = {
   colors: true,
   singleRun: true,
   browserify: {
-    debug: true,
-    transform: [istanbul({
-      ignore: ['**/node_modules/**'],
-      defaultIgnore: true
-    }), babelify.configure({
-      presets: ['es2015']
-    })]
+    transform: [
+      'rollupify', // this needs to happen before babelify
+      babelify.configure({
+        presets: ['es2015']
+      }),
+      istanbul({
+        ignore: ['**/node_modules/**'],
+        defaultIgnore: true
+      })
+    ]
   },
   coverageReporter: {
     type: 'lcovonly',

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "nprogress": "^0.2.0",
     "responsive-filenames": "^1.2.0",
     "rivets": "^0.8.1",
+    "rollupify": "^0.2.0",
     "selection-range": "^1.0.1",
     "striptags": "^2.0.2",
     "text-model": "^0.2.0",

--- a/services/cid.js
+++ b/services/cid.js
@@ -7,7 +7,7 @@ var counter, base;
 base = 'cid-' + Math.floor(Math.random() * 100) + (new Date()).getTime(); // Pretty unique base
 counter = 0;
 
-module.exports = function () {
+export default function () {
   counter += 1; // Increment
   return base + counter;
 };

--- a/services/cid.test.js
+++ b/services/cid.test.js
@@ -1,4 +1,4 @@
-var cid = require('./cid');
+import cid from './cid';
 
 describe('cid', function () {
 

--- a/services/cid.test.js
+++ b/services/cid.test.js
@@ -1,14 +1,10 @@
 import cid from './cid';
 
 describe('cid', function () {
-
   it('returns unique ids', function () {
-
     var firstId = cid(),
       secondId = cid();
 
     expect(firstId).to.not.equal(secondId);
-
   });
-
 });


### PR DESCRIPTION
* use rollupify in `gulp scripts`
* use rollupify in `karma`
* updated `cid` service to test it out

NOTE: As we migrate modules to the es6 module syntax, make sure to do modules with the fewest dependencies first.