### PR TITLE
eliminate extra api call when saving components

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -189,28 +189,26 @@ function appendToPrev(html, prev) {
  * remove current component from parent
  * @param {object} current
  * @param {object} parent
- * @returns {Function}
+ * @returns {Promise} new html for the parent component
  */
 function removeCurrentFromParent(current, parent) {
-  return function () {
-    return edit.removeFromParentList({el: current.component, ref: current.ref, parentField: parent.field, parentRef: parent.ref});
-  };
+  return edit.removeFromParentList({el: current.component, ref: current.ref, parentField: parent.field, parentRef: parent.ref});
 }
 
 /**
  * focus on the previous component's field
- * @param {object} parent
+ * @param {Element} el
  * @param  {object} prev
  * @param {number} textLength
- * @returns {Promise}
+ * @returns {Function}
  */
-function focusPreviousComponent(parent, prev, textLength) {
-  var newEl = dom.find(parent.component, '[' + references.referenceAttribute + '="' + prev.ref + '"]');
-
-  return focus.focus(newEl, { ref: prev.ref, path: prev.field }).then(function (prevField) {
-    // set caret right before the new text we added
-    select(prevField, { start: prevField.textContent.length - textLength });
-  });
+function focusPreviousComponent(el, prev, textLength) {
+  return function () {
+    return focus.focus(el, { ref: prev.ref, path: prev.field }).then(function (el) {
+      // set caret right before the new text we added
+      select(el, { start: el.textContent.length - textLength });
+    });
+  };
 }
 
 /**
@@ -231,8 +229,8 @@ function removeComponent(el) {
       return appendToPrev(getFieldContents(el), prev)
         .then(function (html) {
           return removeCurrentFromParent(current, parent)
-            .then(render.reloadComponent.bind(null, pre.ref, html))
-            .then(focusPreviousComponent(parent, prev, textLength));
+            .then(render.reloadComponent.bind(null, prev.ref, html))
+            .then(focusPreviousComponent(html, prev, textLength));
         });
     }
   });

--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -202,17 +202,15 @@ function removeCurrentFromParent(current, parent) {
  * @param {object} parent
  * @param  {object} prev
  * @param {number} textLength
- * @returns {Function}
+ * @returns {Promise}
  */
 function focusPreviousComponent(parent, prev, textLength) {
-  return function () {
-    var newEl = dom.find(parent.component, '[' + references.referenceAttribute + '="' + prev.ref + '"]');
+  var newEl = dom.find(parent.component, '[' + references.referenceAttribute + '="' + prev.ref + '"]');
 
-    return focus.focus(newEl, { ref: prev.ref, path: prev.field }).then(function (prevField) {
-      // set caret right before the new text we added
-      select(prevField, { start: prevField.textContent.length - textLength });
-    });
-  };
+  return focus.focus(newEl, { ref: prev.ref, path: prev.field }).then(function (prevField) {
+    // set caret right before the new text we added
+    select(prevField, { start: prevField.textContent.length - textLength });
+  });
 }
 
 /**
@@ -231,9 +229,11 @@ function removeComponent(el) {
       // there's a previous component with the same name!
       // get the contents of the current field, and append them to the previous component
       return appendToPrev(getFieldContents(el), prev)
-        .then(removeCurrentFromParent(current, parent))
-        .then(render.reloadComponent.bind(null, prev.ref))
-        .then(focusPreviousComponent(parent, prev, textLength));
+        .then(function (html) {
+          return removeCurrentFromParent(current, parent)
+            .then(render.reloadComponent.bind(null, pre.ref, html))
+            .then(focusPreviousComponent(parent, prev, textLength));
+        });
     }
   });
 }

--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -253,7 +253,7 @@ function addComponent(el, text) {
   }
 
   return edit.createComponent(current.name, newData)
-    .then(function (res) {
+    .then(function (res) { // todo: when we can POST and get back html, handle it here
       var newRef = res._ref;
 
       return edit.addToParentList({ref: newRef, prevRef: current.ref, parentField: parent.field, parentRef: parent.ref})

--- a/services/edit/cache.js
+++ b/services/edit/cache.js
@@ -113,13 +113,7 @@ function saveThrough(data) {
     exports.getData.cache = new _.memoize.Cache();
     exports.getDataOnly.cache = new _.memoize.Cache();
 
-    // remember new value (it is returned when save is successful; common with REST implementations)
-    result[references.referenceProperty] = uri;
-    control.setReadOnly(result);
-    exports.getDataOnly.cache.set(uri, result);
-
-    // cache version with schema, return version with schema
-    return exports.getData(uri);
+    return result;
   });
 }
 

--- a/services/edit/cache.js
+++ b/services/edit/cache.js
@@ -107,7 +107,7 @@ function saveThrough(data) {
   var uri = data[references.referenceProperty];
 
   return removeExtras(uri, data).then(function (data) {
-    return db.save(uri, data);
+    return db.saveForHTML(uri, data);
   }).then(function (result) {
     // only clear cache if save is successful
     exports.getData.cache = new _.memoize.Cache();

--- a/services/edit/cache.test.js
+++ b/services/edit/cache.test.js
@@ -111,10 +111,10 @@ describe('cache service', function () {
       var data = {_ref: 'foo'};
 
       db.get.returns(Promise.resolve({foo: 'bar'}));
-      db.save.returns(Promise.resolve({foo: 'bar'}));
+      db.saveForHTML.returns(Promise.resolve('some html'));
       db.getSchema.returns(Promise.resolve({foo: 'bar'}));
       return fn(data).then(function () {
-        expect(db.save.called).to.equal(true);
+        expect(db.saveForHTML.called).to.equal(true);
       });
     });
 
@@ -122,7 +122,7 @@ describe('cache service', function () {
       var data = {_ref: 'foo'};
 
       db.get.returns(Promise.resolve({foo: 'bar'}));
-      db.save.returns(Promise.resolve('some html'));
+      db.saveForHTML.returns(Promise.resolve('some html'));
       db.getSchema.returns(Promise.resolve({foo: 'bar'}));
       return fn(data).then(function (result) {
         expect(result).to.equal('some html');

--- a/services/edit/cache.test.js
+++ b/services/edit/cache.test.js
@@ -118,44 +118,14 @@ describe('cache service', function () {
       });
     });
 
-    it('returns read-only', function () {
+    it('returns html string', function () {
       var data = {_ref: 'foo'};
 
       db.get.returns(Promise.resolve({foo: 'bar'}));
-      db.save.returns(Promise.resolve({foo: 'bar'}));
+      db.save.returns(Promise.resolve('some html'));
       db.getSchema.returns(Promise.resolve({foo: 'bar'}));
       return fn(data).then(function (result) {
-        expect(Object.isFrozen(result)).to.equal(true);
-      });
-    });
-
-    it('remembers through getDataOnly (caches return values)', function () {
-      var uri = 'foo',
-        data = {_ref: uri},
-        fetched = {foo: 'bar1'},
-        returnSelf = {foo: 'bar2'},
-        schema = {foo: 'bar'};
-
-      db.get.returns(Promise.resolve(fetched));
-      db.save.returns(Promise.resolve(returnSelf));
-      db.getSchema.returns(Promise.resolve(schema));
-      return fn(data).then(function () {
-        expect(lib.getDataOnly.cache.get(uri)).to.deep.equal({foo: 'bar2', _ref: uri});
-      });
-    });
-
-    it('remembers through getData(caches return values)', function () {
-      var uri = 'foo',
-        data = {_ref: uri},
-        fetched = {foo: 'bar1'},
-        returnSelf = {foo: 'bar2'},
-        schema = {foo: 'bar'};
-
-      db.get.returns(Promise.resolve(fetched));
-      db.save.returns(Promise.resolve(returnSelf));
-      db.getSchema.returns(Promise.resolve(schema));
-      return fn(data).then(function () {
-        expect(lib.getData.cache.get(uri)).to.deep.equal({foo: 'bar2', _ref: uri, _schema: schema});
+        expect(result).to.equal('some html');
       });
     });
   });

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -298,6 +298,22 @@ function save(uri, data) {
 }
 
 /**
+ * save, expecting html to be returned from the server
+ * @param {string} uri
+ * @param {object} data
+ * @returns {Promise}
+ */
+function saveForHTML(uri, data) {
+  assertUri(uri);
+
+  return send(addJsonHeader({
+    method: 'PUT',
+    url: uri + extHtml + '?edit=true',
+    data: data
+  })).then(expectHTMLResult(uri));
+}
+
+/**
  * @param {string} uri
  * @param {object} data
  * @returns {Promise}
@@ -361,6 +377,7 @@ module.exports.getText = getText;
 module.exports.getHead = getHead;
 module.exports.getHTML = getHTML;
 module.exports.save = save;
+module.exports.saveForHTML = saveForHTML;
 module.exports.saveText = saveText;
 module.exports.create = create;
 module.exports.remove = remove;

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -4,6 +4,9 @@ var _ = require('lodash'),
   references = require('../references'),
   site = require('./../site'),
   extHtml = '.html',
+  editMode = '?edit=true',
+  // when we ask for updated component html,
+  // make sure the server knows we're in edit mode
   componentRoute = '/components/',
   schemaEndpoint = '/schema';
 
@@ -279,7 +282,7 @@ function getHead(uri) {
 function getHTML(uri) {
   assertUri(uri);
 
-  return send(uri + extHtml + '?edit=true').then(expectHTMLResult(uri));
+  return send(uri + extHtml + editMode).then(expectHTMLResult(uri));
 }
 
 /**
@@ -308,7 +311,7 @@ function saveForHTML(uri, data) {
 
   return send(addJsonHeader({
     method: 'PUT',
-    url: uri + extHtml + '?edit=true',
+    url: uri + extHtml + editMode,
     data: data
   })).then(expectHTMLResult(uri));
 }

--- a/services/edit/db.test.js
+++ b/services/edit/db.test.js
@@ -241,6 +241,32 @@ describe('db service', function () {
     });
   });
 
+  describe('saveForHTML', function () {
+    var fn = lib[this.title];
+
+    createUriBlockTests(fn);
+
+    it('returns data with schema', function () {
+      respond('<div>ok</div>');
+
+      return fn('foo').then(function (data) {
+        expect(data.getAttribute('data-uri')).to.deep.equal('foo');
+      });
+    });
+
+    it('throws on bad data', function (done) {
+      var data = 'jkfdlsa';
+
+      respond(data);
+
+      fn('foo').then(function () {
+        done('should throw');
+      }, function () {
+        done();
+      });
+    });
+  });
+
   describe('create', function () {
     var fn = lib[this.title];
 

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -86,6 +86,7 @@ function validate(data, schema) {
  * Update data for a component.
  *
  * Note: try to operate on full objects with schemas so we don't have to lookup the schema for validation.
+ * Note: returns the re-rendered html string from the server
  *
  * @param {object} data  data that will be saved
  * @param {string} data._ref  uri to save

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -370,9 +370,7 @@ function addToParentList(opts) {
       // todo: when we can POST and get html back, just handle the parent here
       save(parentData),
       db.getHTML(ref)
-    ]).then(function (results) {
-      return results[1]; // return the child component's html
-    });
+    ]).then(results => results[1]); // return the child component's html
   });
 }
 

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -364,8 +364,15 @@ function addToParentList(opts) {
       parentData[parentField].push(item);
     }
 
-    return save(parentData)
-      .then(db.getHTML.bind(null, ref));
+    return Promise.all([
+      // save the parent and get the child's html in parallel
+      // note: this assumes the child already exists
+      // todo: when we can POST and get html back, just handle the parent here
+      save(parentData),
+      db.getHTML(ref)
+    ]).then(function (results) {
+      return results[1]; // return the child component's html
+    });
   });
 }
 

--- a/services/forms.js
+++ b/services/forms.js
@@ -196,9 +196,9 @@ function close() {
 
       data[references.referenceProperty] = ref;
       return edit.savePartial(data)
-        .then(function () {
+        .then(function (html) {
           removeCurrentForm(container);
-          return render.reloadComponent(ref);
+          return render.reloadComponent(ref, html);
         }).then(function () {
           setEditingStatus(false); // Status as saved.
           cleanMediumEditorDom();

--- a/services/render.js
+++ b/services/render.js
@@ -81,12 +81,19 @@ function addComponentsHandlers(el) {
 /**
  * Reload component with latest HTML from the server.
  * @param {string} ref
+ * @param {string} [html]
  * @returns {Promise}
  */
-function reloadComponent(ref) {
-  return db.getHTML(ref)
-  // ?edit=true so that components will return back edit-mode stuff (if they check for locals.edit)
-  // e.g. clay-tweet and clay-facebook-post load scripts in view mode, but not edit mode
+function reloadComponent(ref, html) {
+  var serverHtml;
+
+  if (html) {
+    serverHtml = Promise.resolve(html);
+  } else {
+    serverHtml = db.getHTML(ref);
+  }
+
+  return serverHtml
     .then(function (el) {
       var currentEls = dom.findAll('[' + references.referenceAttribute + '="' + ref + '"]');
 

--- a/services/render.js
+++ b/services/render.js
@@ -85,13 +85,7 @@ function addComponentsHandlers(el) {
  * @returns {Promise}
  */
 function reloadComponent(ref, html) {
-  var serverHtml;
-
-  if (html) {
-    serverHtml = Promise.resolve(html);
-  } else {
-    serverHtml = db.getHTML(ref);
-  }
+  var serverHtml = html ? Promise.resolve(html) : db.getHTML(ref);
 
   return serverHtml
     .then(function (el) {


### PR DESCRIPTION
This eliminates the extra api call (to get the new rendered template) when saving components. It makes these things faster and more fluid:

* exiting out of component forms
* merging (deleting) paragraphs

It also makes the component creation api calls run in parallel, so those will be marginally faster (we can eliminate the second call entirely when we can POST to `/components/name/instances.html`)

☆.。.:*・°☆.。.:*・°☆.。.:*・°☆.。.:*・°☆
——— **2x speed improvements** ———
☆.。.:*・°☆.。.:*・°☆.。.:*・°☆.。.:*・°☆