### PR TITLE
remove input dep from wysiwyg

### DIFF
--- a/behaviors/soft-maxlength.js
+++ b/behaviors/soft-maxlength.js
@@ -31,24 +31,19 @@ function setText(text, span) {
 /**
  * set styles depending on the remaining length
  * @param {number} remaining
+ * @param {number} max
  * @param {Element} el
  */
-function setStyles(remaining, el) {
+function setStyles(remaining, max, el) {
   var input = getInput(el.parentNode),
     span = el;
 
-  if (remaining > 0) {
+  if (remaining >= 0) {
     toggleClass(false, span, input);
-    setText('Remaining: ' + remaining, span);
-  } else if (remaining === 0) {
-    toggleClass(false, span, input);
-    setText('At the character limit', span);
-  } else if (remaining === -1) {
-    toggleClass(true, span, input);
-    setText(-remaining + ' character over the limit', span);
+    setText(`Remaining: ${remaining} / ${max}`, span);
   } else {
     toggleClass(true, span, input);
-    setText(-remaining + ' characters over the limit', span);
+    setText(`Remaining: ${remaining} / ${max}`, span);
   }
 }
 
@@ -82,7 +77,7 @@ module.exports = function (result, args) {
       max = parseInt(el.getAttribute('data-maxlength')),
       remaining = max - length;
 
-    setStyles(remaining, el);
+    setStyles(remaining, max, el);
   };
 
   el.appendChild(span);

--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -9,7 +9,6 @@ var _ = require('lodash'),
   references = require('../services/references'),
   edit = require('../services/edit'),
   model = require('text-model'),
-  getInput = require('../services/get-input'),
   site = require('../services/site'),
   refAttr = references.referenceAttribute;
 
@@ -484,16 +483,17 @@ module.exports = function (result, args) {
     buttons = args.buttons,
     styled = args.styled,
     enableKeyboardExtras = args.enableKeyboardExtras,
-    textInput = getInput(result.el),
-    field = dom.create(`<p class="wysiwyg-input${ addStyledClass(styled) }" rv-field="${name}" rv-wysiwyg="${name}.data.value" data-wysiwyg-buttons="${buttons.join(',')}"></p>`);
+    field = dom.create(`<label class="input-label">
+      <p class="wysiwyg-input${ addStyledClass(styled) }" rv-field="${name}" rv-wysiwyg="${name}.data.value" data-wysiwyg-buttons="${buttons.join(',')}"></p>
+    </label>`);
 
   // if more than 5 buttons, put the rest on the second tier
   if (buttons.length > 5) {
     buttons.splice(5, 0, 'tieredToolbar'); // clicking this expands the toolbar with a second tier
   }
 
-  // put the rich text field after the input
-  dom.replaceElement(textInput, field);
+  // add the input to the field
+  result.el = field;
 
   // add the binder
   binders.wysiwyg = initWysiwygBinder(enableKeyboardExtras);

--- a/styleguide/_typography.scss
+++ b/styleguide/_typography.scss
@@ -11,6 +11,7 @@ $system-fonts: Helvetica, Arial, sans-serif;
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
+  word-break: inherit;
 }
 
 // our typography


### PR DESCRIPTION
* remove input dep from wysiwyg (fixes #268)
* wysiwyg input should inherit `word-break` property when unstyled
* show "max" length in `soft-maxlength` (fixes #346)