### PR TITLE
treat simple-list like inputs

### DIFF
--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -14,10 +14,12 @@ module.exports = function (result, args) {
   var name = result.name,
     allowRepeat = !!args && !!args.allowRepeatedItems,
     el = dom.create(`
-      <section rv-field="${name}" class="simple-list" rv-simplelist="${name}.data">
-        <span tabindex="0" rv-each-item="${name}.data" class="simple-list-item" rv-class-selected="item._selected" rv-on-click="${name}.selectItem" rv-on-keydown="${name}.keyactions">{ item.text }</span>
-        <input class="simple-list-add" data-allow-repeat=${allowRepeat} rv-on-click="${name}.unselectAll" placeholder="Start typing here&hellip;" />
-      </section>`);
+      <div class="input-label">
+        <div rv-field="${name}" class="simple-list" rv-simplelist="${name}.data">
+          <span tabindex="0" rv-each-item="${name}.data" class="simple-list-item" rv-class-selected="item._selected" rv-on-click="${name}.selectItem" rv-on-keydown="${name}.keyactions">{ item.text }</span>
+          <input class="simple-list-add" data-allow-repeat=${allowRepeat} rv-on-click="${name}.unselectAll" placeholder="Start typing here&hellip;" />
+        </div>
+      </div>`);
 
   /**
    * unselect all items

--- a/behaviors/simple-list.test.js
+++ b/behaviors/simple-list.test.js
@@ -19,7 +19,7 @@ describe(dirname, function () {
   describe(filename, function () {
     describe('el', function () {
       it('has field property', function () {
-        var resultEl = lib(fixture).el;
+        var resultEl = lib(fixture).el.firstElementChild;
 
         expect(resultEl.getAttribute(references.fieldAttribute)).to.equal('foo');
       });

--- a/services/get-input.js
+++ b/services/get-input.js
@@ -2,11 +2,11 @@
 var dom = require('@nymag/dom');
 
 function getInput(el) {
-  return dom.find(el, '.checkbox-group') || dom.find(el, 'input') || dom.find(el, 'textarea') || dom.find(el, '.wysiwyg-input');
+  return dom.find(el, '.checkbox-group') || dom.find(el, '.simple-list') || dom.find(el, 'input') || dom.find(el, 'textarea') || dom.find(el, '.wysiwyg-input');
 }
 
 function isInput(el) {
-  return !!el && (el.nodeName === 'INPUT' || el.nodeName === 'TEXTAREA' || el.classList.contains('wysiwyg-input'));
+  return !!el && (el.nodeName === 'INPUT' || el.nodeName === 'TEXTAREA' || el.classList.contains('wysiwyg-input') || el.classList.contains('simple-list'));
 }
 
 module.exports = getInput;

--- a/services/get-input.test.js
+++ b/services/get-input.test.js
@@ -4,6 +4,53 @@ var dirname = __dirname.split('/').pop(),
 
 describe(dirname, function () {
   describe(filename, function () {
+    var formEl;
+
+    beforeEach(function () {
+      formEl = document.createElement('div');
+    });
+
+    it('finds checkbox groups', function () {
+      var el = document.createElement('div');
+
+      el.classList.add('checkbox-group');
+      formEl.appendChild(el);
+      expect(lib(formEl)).to.equal(el);
+    });
+
+    it('finds simple lists BEFORE inputs', function () {
+      // note: simple-list contains an input, so we need to match before `input`
+      var el = document.createElement('div'),
+        input = document.createElement('input');
+
+      el.classList.add('simple-list');
+      formEl.appendChild(el);
+      formEl.appendChild(input);
+      expect(lib(formEl)).to.equal(el);
+    });
+
+    it('finds inputs', function () {
+      var input = document.createElement('input');
+
+      formEl.appendChild(input);
+      expect(lib(formEl)).to.equal(input);
+    });
+
+    it('finds textareas', function () {
+      var el = document.createElement('textarea');
+
+      formEl.appendChild(el);
+      expect(lib(formEl)).to.equal(el);
+    });
+
+    it('finds wysiwyg inputs', function () {
+      var el = document.createElement('p');
+
+      el.classList.add('wysiwyg-input');
+      formEl.appendChild(el);
+      expect(lib(formEl)).to.equal(el);
+    });
+
     describe('isInput', function () {
       var fn = lib[this.title];
 
@@ -27,6 +74,14 @@ describe(dirname, function () {
         var el = document.createElement('div');
 
         el.classList.add('wysiwyg-input');
+
+        expect(fn(el)).to.equal(true);
+      });
+
+      it('returns true for elements with the .simple-list class', function () {
+        var el = document.createElement('div');
+
+        el.classList.add('simple-list');
 
         expect(fn(el)).to.equal(true);
       });


### PR DESCRIPTION
treats simple lists like inputs:

* wraps them in `.input-label` so labels can be applied
* updates `getInput` to match them so other behaviors can be added before / after

![screen shot 2016-04-14 at 11 13 32 am](https://cloud.githubusercontent.com/assets/447522/14533204/22c7b594-0232-11e6-82a5-7ccd6b6bdf82.png)
