### PR TITLE
updated field helpers, focus

### DIFF
--- a/decorators/focus.js
+++ b/decorators/focus.js
@@ -3,7 +3,7 @@ var _ = require('lodash'),
   forms = require('../services/forms'),
   select = require('../services/select'),
   dom = require('@nymag/dom'),
-  getInput = require('../services/field-helpers').getInput,
+  helpers = require('../services/field-helpers'),
   componentList = require('./component-list'),
   currentFocus;
 
@@ -45,16 +45,16 @@ function focus(el, options, e) {
     .then(function () {
       select.select(el);
       currentFocus = el;
-      return forms.open(options.ref, el, options.path, e).then(function () {
-        var firstField = dom.find('[' + references.fieldAttribute + ']'),
+      return forms.open(options.ref, el, options.path, e).then(function (formEl) {
+        var firstField = helpers.getField(formEl),
           firstFieldInput;
 
         // focus on the first field in the form we just created
-        if (firstField && getInput.isInput(firstField)) {
+        if (firstField && helpers.isInput(firstField)) {
           // first field is itself an input
           firstField.focus();
         } else if (firstField) {
-          firstFieldInput = getInput(firstField);
+          firstFieldInput = helpers.getInput(firstField);
           // first field is a list or something, that contains an input as a child
           if (firstFieldInput) {
             firstFieldInput.focus();

--- a/services/field-helpers.js
+++ b/services/field-helpers.js
@@ -11,7 +11,7 @@ function getInput(el) {
 }
 
 function isInput(el) {
-  return !!el && (el.nodeName === 'INPUT' || el.nodeName === 'TEXTAREA' || el.classList.contains('wysiwyg-input') || el.classList.contains('simple-list'));
+  return !!el && (el.nodeName === 'INPUT' || el.nodeName === 'TEXTAREA' || el.classList.contains('wysiwyg-input'));
 }
 
 module.exports.getField = getField;

--- a/services/field-helpers.test.js
+++ b/services/field-helpers.test.js
@@ -87,14 +87,6 @@ describe(dirname, function () {
 
         expect(fn(el)).to.equal(true);
       });
-
-      it('returns true for elements with the .simple-list class', function () {
-        var el = document.createElement('div');
-
-        el.classList.add('simple-list');
-
-        expect(fn(el)).to.equal(true);
-      });
     });
   });
 });


### PR DESCRIPTION
* removed `.simple-list` from `isInput` (I should have removed it when I created `getField`)
* updated field-helpers tests
* updated `focus` service to properly focus on the first input when opening a form