### PR TITLE
updates to magic button

### DIFF
--- a/behaviors/magic-button.js
+++ b/behaviors/magic-button.js
@@ -178,6 +178,38 @@ function doMagic(e, bindings) {
 
 /**
  * Create magic button.
+ *
+ * ☆.。.:*・°☆.。.:*・°☆.。.:*・°☆.。.:*・°☆
+ *
+ * Magic buttons are extremely powerful, but can be a little confusing to configure.
+ * This is what they generally look like:
+ *
+ * 1. specify a `field` or `component`. The button will grab the value or ref, respectively
+ * 2. specify a `transform`. Transforms are useful when doing api calls with that data
+ * 3. specify a `url` to do the api call against. It will do a GET request to `url + transformed data`
+ * 4. specify a `property` to grab from the result of that api call. You can use _.get() syntax, e.g. `foo.bar[0].baz`
+ *
+ * All of these arguments are optional!
+ *
+ * Here are some examples:
+ *
+ * (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧ "just grab the primary headline"
+ * field: primaryHeadline
+ *
+ * (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧ "grab a caption from mediaplay"
+ * field: url
+ * transform: mediaplayUrl (strips out stuff that ambrose does't want in the api call)
+ * url: [ambrose api for images]
+ * property: metadata.credit
+ *
+ * (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧ "grab the url of the first mediaplay-image on this page"
+ * component: mediaplay-image
+ * transform: getComponentInstance (this transforms the full component uri into a ref we can pop onto the end of our site prefix)
+ * url: $SITE_PREFIX (this is a ~ special token ~ that evaluates to the prefix of current site, so you can do api calls against your own clay instance)
+ * property: url
+ *
+ * ☆.。.:*・°☆.。.:*・°☆.。.:*・°☆.。.:*・°☆
+ *
  * @param {{name: string, bindings: {}}} result
  * @param {object} args  described in detail below:
  * @param {string} [args.field] grab the value of this field


### PR DESCRIPTION
* added optional `component` argument, to look up component refs on the page
* added `$SITE_PREFIX` token to make api calls against the current clay instance
* added `getComponentInstance` transform to get the component instance from a full uri (to make api calls)

This allows the magic button to query Clay itself for arbitrary data on components, e.g. to populate the article `feedImgUrl` from the first `mediaplay-image` component.