### PR TITLE
added codemirror behavior with scss

### DIFF
--- a/behaviors/codemirror.js
+++ b/behaviors/codemirror.js
@@ -1,0 +1,60 @@
+var Codemirror = require('codemirror'),
+  dom = require('@nymag/dom');
+
+// scss mode
+require('codemirror/mode/css/css');
+// show selections
+require('codemirror/addon/selection/active-line.js');
+
+function initCodemirror() {
+  return {
+    publish: true,
+    bind: function (el) {
+      // this is called when the binder initializes
+      var mode = el.getAttribute('data-codemirror-mode'),
+        observer = this.observer,
+        data = observer.value() || '', // don't print 'undefined' if there's no data
+        editor = Codemirror.fromTextArea(el, {
+          value: data,
+          mode: mode,
+          lint: true,
+          styleActiveLine: true,
+          lineNumbers: true
+        });
+
+      // refresh the codemirror instance after it instantiates
+      // wait until it gets redrawn in the dom first
+      setTimeout(function () {
+        editor.refresh();
+      }, 0);
+
+      editor.on('change', function (instance) {
+        observer.setValue(instance.getValue());
+      });
+    }
+  };
+}
+
+/**
+ * Create WYSIWYG text editor.
+ * @param {{name: string, el: Element, binders: {}}} result
+ * @param {object} args  Described in detail below:
+ * @param {string} args.mode  language to display (e.g. scss, javascript, etc)
+ * @returns {object}
+ */
+module.exports = function (result, args) {
+  var name = result.name,
+    binders = result.binders,
+    mode = args.mode,
+    field = dom.create(`<label class="input-label">
+      <textarea class="codemirror" rv-field="${name}" rv-codemirror="${name}.data.value" data-codemirror-mode="${mode}" rv-value="${name}.data.value"></textarea>
+    </label>`);
+
+  // add the input to the field
+  result.el = field;
+
+  // add the binder
+  binders.codemirror = initCodemirror();
+
+  return result;
+};

--- a/behaviors/codemirror.scss
+++ b/behaviors/codemirror.scss
@@ -1,0 +1,9 @@
+@import '../styleguide/inputs';
+@import '../node_modules/codemirror/lib/codemirror';
+
+.CodeMirror {
+  @include input();
+
+  font-family: monospace;
+  padding: 0;
+}

--- a/client.js
+++ b/client.js
@@ -33,6 +33,7 @@ behaviors.add('label', require('./behaviors/label'));
 behaviors.add('segmented-button', require('./behaviors/segmented-button'));
 behaviors.add('page-ref', require('./behaviors/page-ref'));
 behaviors.add('magic-button', require('./behaviors/magic-button'));
+behaviors.add('codemirror', require('./behaviors/codemirror'));
 
 // add default decorators
 decorators.add(require('./decorators/placeholder'));

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "chalk": "^1.1.1",
+    "codemirror": "^5.14.0",
     "dollar-slice": "^2.1.0",
     "domify": "^1.3.3",
     "dragula": "^3.5.4",


### PR DESCRIPTION
this allows us to use a nicely-formatted text area to add styles. In the future, we can use the same behavior to do:

* yaml for custom searches
* linting of styles
* lots of other neat things

![screen shot 2016-04-20 at 5 32 50 pm](https://cloud.githubusercontent.com/assets/447522/14691202/f4caff5c-071d-11e6-87a9-e175313c5023.png)
