### PR TITLE
drag and drop all the things

### DIFF
--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -168,6 +168,19 @@ function getComponentDepth(handle, container) {
 }
 
 /**
+ * determine if a component is draggable inside a specific container
+ * @param {Element} handle
+ * @param {Element} container
+ * @returns {boolean}
+ */
+function isDraggable(handle, container) {
+  // components are draggable if the handle is the component element and it's a direct child of the container (depth 0)
+  // OR if the handle is some OTHER element inside the direct child component (depth 1)
+  return !!handle.getAttribute(references.referenceAttribute) && getComponentDepth(handle, container) === 0
+    || !handle.getAttribute(references.referenceAttribute) && getComponentDepth(handle, container) === 1;
+}
+
+/**
  * Add dragula.
  * @param {Element} el
  * @param {{ref: string, path: string, data: object}} options
@@ -181,7 +194,7 @@ function addDragula(el, options) {
       moves: function (selectedItem, container, handle) {
         // only allow direct child components of a list to be dragged
         // this allows for nested component lists + dragdrop
-        return selectedItem.classList.contains('drag') && getComponentDepth(handle, container) <= 1;
+        return selectedItem.classList.contains('drag') && isDraggable(handle, container);
       }
     });
 

--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -177,10 +177,11 @@ function addDragula(el, options) {
     dragItemClass = 'dragula-item',
     dragItemUnsavedClass = 'dragula-not-saved',
     drag = dragula([el], {
+      ignoreInputTextSelection: true, // allow selecting text in draggable components
       moves: function (selectedItem, container, handle) {
         // only allow direct child components of a list to be dragged
         // this allows for nested component lists + dragdrop
-        return handle.classList.contains('drag') && getComponentDepth(handle, container) === 1;
+        return selectedItem.classList.contains('drag') && getComponentDepth(handle, container) <= 1;
       }
     });
 

--- a/services/select.js
+++ b/services/select.js
@@ -284,7 +284,6 @@ function addDragOption(componentBar, el) {
     dragIcon = dom.create(`<img src="${site.get('assetPath')}/media/components/clay-kiln/component-bar-drag.svg" alt="Drag" class="drag-icon"></span>`);
 
   selectedLabel.setAttribute('title', `Drag to reorder: ${label(selectedLabel.getAttribute('title'))}`);
-  // selectedLabel.querySelector('.selected-label-inner').classList.add('drag');
   el.classList.add('drag');
   selectedLabel.insertBefore(dragIcon, selectedLabel.firstChild);
 }

--- a/services/select.js
+++ b/services/select.js
@@ -276,16 +276,17 @@ function addParentLabel(componentBar, parentEl) {
 /**
  * Add drag within a component list.
  * @param {Element} componentBar
+ * @param {Element} el (component element)
  */
-function addDragOption(componentBar) {
+function addDragOption(componentBar, el) {
   // `drag` class is applied to the `img` and and selector elements to simplify dragula logic.
   var selectedLabel = componentBar.querySelector('.selected-label'),
-    el = dom.create(`<img src="${site.get('assetPath')}/media/components/clay-kiln/component-bar-drag.svg" alt="Drag" class="drag drag-icon"></span>`);
+    dragIcon = dom.create(`<img src="${site.get('assetPath')}/media/components/clay-kiln/component-bar-drag.svg" alt="Drag" class="drag-icon"></span>`);
 
   selectedLabel.setAttribute('title', `Drag to reorder: ${label(selectedLabel.getAttribute('title'))}`);
-  selectedLabel.querySelector('.selected-label-inner').classList.add('drag');
-  selectedLabel.classList.add('drag');
-  selectedLabel.insertBefore(el, selectedLabel.firstChild);
+  // selectedLabel.querySelector('.selected-label-inner').classList.add('drag');
+  el.classList.add('drag');
+  selectedLabel.insertBefore(dragIcon, selectedLabel.firstChild);
 }
 
 /**
@@ -327,7 +328,7 @@ function addParentOptions(componentBar, el, ref) {
         var componentListField = getParentComponentListField(el, parentSchema);
 
         if (componentListField) {
-          addDragOption(componentBar);
+          addDragOption(componentBar, el);
           addDeleteOption(componentBar, {el: el, ref: ref, parentField: componentListField, parentRef: parentRef});
         }
       });

--- a/services/select.test.js
+++ b/services/select.test.js
@@ -242,7 +242,7 @@ describe(dirname, function () {
         // Problem is that addParentOptions returns a promise, but the handler returns an element synchronously.
         // Todo: get all the data in one pass or better way to get the closest field?
         window.setTimeout(function () {
-          expect(el.querySelector('.component-bar .drag')).to.not.equal(null); // Has drag.
+          expect(el.querySelector('.component-bar .drag-icon')).to.not.equal(null); // Has drag icon.
           expect(el.querySelector('.component-bar .delete')).to.not.equal(null); // Has delete.
           done();
         }, 0);
@@ -263,7 +263,7 @@ describe(dirname, function () {
         fn(el, options);
 
         window.setTimeout(function () {
-          expect(el.querySelector('.component-bar .drag')).to.equal(null); // Has drag.
+          expect(el.querySelector('.component-bar .drag-icon')).to.equal(null); // Has drag icon.
           expect(el.querySelector('.component-bar .delete')).to.equal(null); // Has delete.
           done();
         }, 0);

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -54,4 +54,4 @@ $overlay-shadow: rgba(0, 0, 0, .07);
 $input-shadow: rgba(0, 0, 0, .3);
 $drag-shadow: rgba(0, 0, 0, .3); // different use case than input-shadow
 $drag-error: rgba(215, 39, 39, .41);
-$drag-saving:  rgba($blue-75, .41);
+$drag-saving: rgba($blue-75, .41);

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -54,3 +54,4 @@ $overlay-shadow: rgba(0, 0, 0, .07);
 $input-shadow: rgba(0, 0, 0, .3);
 $drag-shadow: rgba(0, 0, 0, .3); // different use case than input-shadow
 $drag-error: rgba(215, 39, 39, .41);
+$drag-saving:  rgba($blue-75, .41);

--- a/styleguide/component-list-drag.scss
+++ b/styleguide/component-list-drag.scss
@@ -41,6 +41,6 @@
 .dragula-item {}
 /* Indicate that the re-ordering has not been saved. */
 .dragula-not-saved {
-  background: $drag-error !important;
+  background: $drag-saving !important;
   transition: background-color 300ms linear;
 }


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/Mya33wZK/320-drag-and-drop-on-components)
* allows you to drag and drop without having to select components
* (backwards-compatible) you can still drag the component selector if you want
* works with lists inside of lists

**NOTE:** If you hold down command (⌘) when selecting text, it will allow you to select multiple paragraphs. This feature assumes that dragging is the more common action (and selecting less common, at least over multiple paragraphs).

![f56d5eb3-4fe2-43ad-8732-04ab781b1003-476-0004409df903c65d](https://cloud.githubusercontent.com/assets/447522/15017396/6182b96c-11e3-11e6-8690-e4ac8f1638ed.gif)

