### PR TITLE
updated add-component experience

### DIFF
--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -79,7 +79,8 @@ module.exports = function () {
   constructor.prototype = {
     events: {
       '.filtered-input keyup': 'onInputKeyup',
-      '.filtered-item keyup': 'onItemKeyup'
+      '.filtered-item keyup': 'onItemKeyup',
+      '.filtered-item click': 'onItemClick'
     },
 
     onInputKeyup: function (e) {
@@ -131,6 +132,11 @@ module.exports = function () {
         addComponent(this.pane, this.field, currentItem.getAttribute('data-item-name'))
           .then(() => pane.close()); // only close if we added successfully
       }
+    },
+
+    onItemClick: function (e) {
+      addComponent(this.pane, this.field, e.target.getAttribute('data-item-name'))
+        .then(() => pane.close()); // only close if we added successfully
     }
   };
   return constructor;

--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -106,6 +106,9 @@ module.exports = function () {
       } else if (key === 'enter' && available.length === 1) {
         addComponent(this.pane, this.field, available[0].getAttribute('data-item-name'))
           .then(() => pane.close()); // only close if we added successfully
+      } else if (key === 'enter') {
+        input.classList.add('kiln-shake');
+        setTimeout(() => input.classList.remove('kiln-shake'), 301); // length of the animation + 1
       } else if (key === 'esc') {
         pane.close();
       } else {

--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -75,7 +75,11 @@ module.exports = function () {
     this.list = dom.find(el, '.filtered-items'),
     this.items = dom.findAll(this.list, '.filtered-item');
 
-    setTimeout(() => this.input.focus(), 100); // give the pane a moment to animate in
+    // give the pane a moment to animate in, then focus the input
+    setTimeout(() => this.input.focus(), 100);
+
+    // set the height so when we filter it won't jump around
+    this.list.style.height = getComputedStyle(this.list).height;
   }
 
   constructor.prototype = {

--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -85,6 +85,7 @@ module.exports = function () {
   constructor.prototype = {
     events: {
       '.filtered-input keyup': 'onInputKeyup',
+      '.filtered-item keydown': 'onItemKeydown',
       '.filtered-item keyup': 'onItemKeyup',
       '.filtered-item click': 'onItemClick'
     },
@@ -112,10 +113,20 @@ module.exports = function () {
       }
     },
 
+    onItemKeydown: function (e) {
+      // simulate active states when pressing enter
+      if (keyCode(e) === 'enter') {
+        e.target.classList.add('active');
+      }
+    },
+
     onItemKeyup: function (e) {
       var key = keyCode(e),
         available = getAvailable(this.items),
         currentItem = e.target;
+
+      // remove any active state if it exists
+      currentItem.classList.remove('active');
 
       // if it's down or up, transfer focus
       // note: tab and shift+tab will work natively with the visible items

--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -11,8 +11,10 @@ var pane = require('../services/pane'),
  */
 function filter(val, items) {
   _.each(items, function (item) {
-    var label = item.textContent,
-      name = item.getAttribute('data-item-name');
+    var label = item.textContent.toLowerCase(),
+      name = item.getAttribute('data-item-name').toLowerCase();
+
+    val = val.toLowerCase();
 
     if (_.includes(label, val) || _.includes(name, val)) {
       item.classList.remove('filtered');

--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -74,6 +74,8 @@ module.exports = function () {
     this.input = dom.find(el, '.filtered-input');
     this.list = dom.find(el, '.filtered-items'),
     this.items = dom.findAll(this.list, '.filtered-item');
+
+    setTimeout(() => this.input.focus(), 100); // give the pane a moment to animate in
   }
 
   constructor.prototype = {

--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -84,10 +84,21 @@ module.exports = function () {
 
   constructor.prototype = {
     events: {
+      '.filtered-input keydown': 'onInputKeydown',
       '.filtered-input keyup': 'onInputKeyup',
       '.filtered-item keydown': 'onItemKeydown',
       '.filtered-item keyup': 'onItemKeyup',
       '.filtered-item click': 'onItemClick'
+    },
+
+    onInputKeydown: function (e) {
+      var key = keyCode(e),
+        available = getAvailable(this.items);
+
+      // simulate active states when pressing enter
+      if (key === 'enter' && available.length === 1) {
+        available[0].classList.add('active');
+      }
     },
 
     onInputKeyup: function (e) {
@@ -104,6 +115,7 @@ module.exports = function () {
       if (key === 'down') {
         focusFirst(available); // focus on first available item in list
       } else if (key === 'enter' && available.length === 1) {
+        available[0].classList.remove('active');
         addComponent(this.pane, this.field, available[0].getAttribute('data-item-name'))
           .then(() => pane.close()); // only close if we added successfully
       } else if (key === 'enter') {

--- a/controllers/add-component-pane.js
+++ b/controllers/add-component-pane.js
@@ -1,0 +1,137 @@
+var pane = require('../services/pane'),
+  addComponent = require('../services/add-component'),
+  dom = require('@nymag/dom'),
+  keyCode = require('keycode');
+
+/**
+ * filter items in the list, based on the label or name
+ * todo: in the future, allow more robust searching (description, etc)
+ * @param {string} val
+ * @param {NodeList} items
+ */
+function filter(val, items) {
+  _.each(items, function (item) {
+    var label = item.textContent,
+      name = item.getAttribute('data-item-name');
+
+    if (_.includes(label, val) || _.includes(name, val)) {
+      item.classList.remove('filtered');
+    } else {
+      item.classList.add('filtered');
+    }
+  });
+}
+
+/**
+ * get the available items
+ * @param {NodeList} items
+ * @returns {array}
+ */
+function getAvailable(items) {
+  return _.filter(items, (item) => !item.classList.contains('filtered'));
+}
+
+/**
+ * focus first available item in list
+ * @param {NodeList} list
+ */
+function focusFirst(list) {
+  list[0].focus();
+}
+
+/**
+ * focus next available item
+ * @param {Element} current
+ * @param {NodeList} list
+ */
+function focusNext(current, list) {
+  var index = list.indexOf(current);
+
+  if (index < list.length) {
+    list[index + 1].focus();
+  }
+}
+
+/**
+ * focus previous available item
+ * @param {Element} current
+ * @param {NodeList} list
+ */
+function focusPrev(current, list) {
+  var index = list.indexOf(current);
+
+  if (index > 0) {
+    list[index - 1].focus();
+  }
+}
+
+module.exports = function () {
+  function constructor(el, options) {
+    // parent options, passed in from the component list
+    this.pane = options.pane;
+    this.field = options.field;
+    // useful elements
+    this.input = dom.find(el, '.filtered-input');
+    this.list = dom.find(el, '.filtered-items'),
+    this.items = dom.findAll(this.list, '.filtered-item');
+  }
+
+  constructor.prototype = {
+    events: {
+      '.filtered-input keyup': 'onInputKeyup',
+      '.filtered-item keyup': 'onItemKeyup'
+    },
+
+    onInputKeyup: function (e) {
+      var input = this.input,
+        key = keyCode(e),
+        available = getAvailable(this.items);
+
+      // if it's down, transfer focus
+      // if it's enter, try to add component
+      // if it's esc, exit the pane
+      // if it's anything else, try to filter the list
+      // note: tab will work natively
+
+      if (key === 'down') {
+        focusFirst(available); // focus on first available item in list
+      } else if (key === 'enter' && available.length === 1) {
+        addComponent(this.pane, this.field, available[0].getAttribute('data-item-name'))
+          .then(() => pane.close()); // only close if we added successfully
+      } else if (key === 'esc') {
+        pane.close();
+      } else {
+        filter(input.value, this.items);
+      }
+    },
+
+    onItemKeyup: function (e) {
+      var key = keyCode(e),
+        available = getAvailable(this.items),
+        currentItem = e.target;
+
+      // if it's down or up, transfer focus
+      // note: tab and shift+tab will work natively with the visible items
+      // if it's enter, try to add that component
+      // if it's esc, exit the pane
+
+      if (key === 'down') {
+        focusNext(currentItem, available);
+      } else if (key === 'up') {
+        if (currentItem === available[0]) {
+          // at the top of the available items, transfer focus to input
+          this.input.focus();
+        } else {
+          // transfer focus up
+          focusPrev(currentItem, available);
+        }
+      } else if (key === 'esc') {
+        pane.close();
+      } else if (key === 'enter') {
+        addComponent(this.pane, this.field, currentItem.getAttribute('data-item-name'))
+          .then(() => pane.close()); // only close if we added successfully
+      }
+    }
+  };
+  return constructor;
+};

--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -3,7 +3,8 @@ var _ = require('lodash'),
   dom = require('@nymag/dom'),
   edit = require('../services/edit'),
   dragula = require('dragula'),
-  addComponent = require('../services/add-component');
+  addComponent = require('../services/add-component'),
+  paneService = require('../services/pane');
 
 /**
  * map through components, filtering out excluded
@@ -203,18 +204,15 @@ function handler(el, options) {
   button = dom.find(pane, '.open-add-components');
 
   // add click events to toggle pane
-  button.addEventListener('click', function (e) {
+  button.addEventListener('click', function () {
     var addableComponents = button.getAttribute('data-components').split(',');
 
     if (addableComponents.length === 1) {
       addComponent(pane, args.field, addableComponents[0]);
     } else {
       // open the add components pane
-      console.log('\nI can add these components:')
-      console.log(addableComponents)
+      paneService.openAddComponent(addableComponents, { pane: pane, field: args.field });
     }
-
-    e.stopPropagation(); // stop unselect() or unfocus() from firing
   });
 
   // wrap the draggable items so that the pane is not in the drop area.

--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -2,49 +2,8 @@ var _ = require('lodash'),
   references = require('../services/references'),
   dom = require('@nymag/dom'),
   edit = require('../services/edit'),
-  render = require('../services/render'),
-  label = require('../services/label'),
-  dragula = require('dragula');
-
-/**
- * remove parent placeholder
- * @param {{ref: string, path: string}} field
- */
-function removeParentPlaceholder(field) {
-  // component > field > div > placeholder
-  var parent = document.querySelector('[' + references.referenceAttribute + '="' + field.ref + '"]'),
-    list = parent && parent.querySelector('[' + references.editableAttribute + '="' + field.path + '"]'),
-    div = list && dom.getFirstChildElement(list),
-    placeholder = div && dom.getFirstChildElement(div);
-
-  // remove component list placeholder if it exists
-  if (placeholder && placeholder.classList.contains('kiln-placeholder')) {
-    dom.removeElement(placeholder);
-  }
-}
-
-/**
- * Create click handler for adding a component
- * @param {Element} pane
- * @param {{ref: string, path: string}} field
- * @param {string} name
- * @returns {Promise}
- */
-function addComponent(pane, field, name) {
-  removeParentPlaceholder(field);
-  return edit.createComponent(name)
-    .then(function (res) {
-      var newRef = res._ref;
-
-      return edit.addToParentList({ref: newRef, parentField: field.path, parentRef: field.ref})
-        .then(function (newEl) {
-          var dropArea = pane.previousElementSibling;
-
-          dropArea.appendChild(newEl);
-          return render.addComponentsHandlers(newEl);
-        });
-    });
-}
+  dragula = require('dragula'),
+  addComponent = require('../services/add-component');
 
 /**
  * map through components, filtering out excluded

--- a/services/add-component.js
+++ b/services/add-component.js
@@ -1,0 +1,66 @@
+var references = require('../services/references'),
+  dom = require('@nymag/dom'),
+  edit = require('../services/edit'),
+  render = require('../services/render');
+
+/**
+ * find placeholders to remove from the parent
+ * @param {{ref: string, path: string}} field
+ * @returns {Element|null}
+ */
+function getRemovablePlaceholder(field) {
+  // component > field > div > placeholder
+  var parent = document.querySelector('[' + references.referenceAttribute + '="' + field.ref + '"]'),
+    list = parent && parent.querySelector('[' + references.editableAttribute + '="' + field.path + '"]'),
+    div = list && dom.getFirstChildElement(list),
+    placeholder = div && dom.getFirstChildElement(div);
+
+  // only remove regular placeholders, not permanent placeholders
+  if (placeholder && placeholder.classList.contains('kiln-placeholder')) {
+    return placeholder;
+  } else {
+    return null;
+  }
+}
+
+/**
+ * remove parent placeholder
+ * @param {{ref: string, path: string}} field
+ */
+function removeParentPlaceholder(field) {
+  // component > field > div > placeholder
+  var placeholder = getRemovablePlaceholder(field);
+
+  // remove component list placeholder if it exists
+  if (placeholder) {
+    dom.removeElement(placeholder);
+  }
+}
+
+/**
+ * Add a component to a specified list
+ * @param {Element} pane (add component button, put the new component above this)
+ * @param {{ref: string, path: string}} field (parent data)
+ * @param {string} name of the component
+ * @returns {Promise}
+ */
+function addComponent(pane, field, name) {
+  removeParentPlaceholder(field);
+  return edit.createComponent(name)
+    .then(function (res) {
+      var newRef = res._ref;
+
+      return edit.addToParentList({ref: newRef, parentField: field.path, parentRef: field.ref})
+        .then(function (newEl) {
+          var dropArea = pane.previousElementSibling;
+
+          dropArea.appendChild(newEl);
+          return render.addComponentsHandlers(newEl);
+        });
+    });
+}
+
+module.exports = addComponent;
+
+// for testing
+module.exports.getRemovablePlaceholder = getRemovablePlaceholder; // this function contains the logic that removeParentPlaceholder uses

--- a/services/add-component.test.js
+++ b/services/add-component.test.js
@@ -1,0 +1,110 @@
+var dirname = __dirname.split('/').pop(),
+  filename = __filename.split('/').pop().split('.').shift(),
+  lib = require('./add-component'),
+  dom = require('@nymag/dom'),
+  edit = require('./edit'),
+  render = require('./render');
+
+describe(dirname, function () {
+  describe(filename, function () {
+    var sandbox;
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(edit);
+      sandbox.stub(render);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('creates component and adds it before the pane', function () {
+      var pane = dom.create('<div class="pane"></div>');
+
+      document.body.appendChild(pane);
+      // stub stuff
+      edit.createComponent.returns(Promise.resolve({
+        _ref: 'newRef'
+      }));
+      edit.addToParentList.returns(Promise.resolve(dom.create('<div class="new-component"></div>')));
+      lib(pane, { field: null, ref: null }, 'fakeName').then(function () {
+        expect(dom.find(pane.previousElementSibling, '.new-component')).to.not.equal(null);
+      });
+    });
+
+    describe('getRemovablePlaceholder', function () {
+      var fn = lib[this.title];
+
+      it('does nothing if no parent found', function () {
+        expect(fn({
+          ref: 'fakeParentPlaceholder1',
+          path: 'foo'
+        })).to.equal(null);
+      });
+      it('does nothing if no component list found in parent', function () {
+        var parent = dom.create('<section data-uri="fakeParentPlaceholder2"></section>');
+
+        document.body.appendChild(parent);
+        expect(fn({
+          ref: 'fakeParentPlaceholder2',
+          path: 'foo'
+        })).to.equal(null);
+      });
+      it('does nothing if no wrapper div found in list', function () {
+        var parent = dom.create(`<section data-uri="fakeParentPlaceholder3">
+          <div data-editable="foo"></div>
+        </section>`);
+
+        document.body.appendChild(parent);
+        expect(fn({
+          ref: 'fakeParentPlaceholder3',
+          path: 'foo'
+        })).to.equal(null);
+      });
+      it('does nothing if no placeholder found in wrapper div', function () {
+        var parent = dom.create(`<section data-uri="fakeParentPlaceholder4">
+          <div data-editable="foo">
+            <div></div>
+          </div>
+        </section>`);
+
+        document.body.appendChild(parent);
+        expect(fn({
+          ref: 'fakeParentPlaceholder4',
+          path: 'foo'
+        })).to.equal(null);
+      });
+      it('does nothing if placeholder is permanent', function () {
+        var parent = dom.create(`<section data-uri="fakeParentPlaceholder5">
+          <div data-editable="foo">
+            <div>
+              <div class="kiln-permanent-placeholder"></div>
+            </div>
+          </div>
+        </section>`);
+
+        document.body.appendChild(parent);
+        expect(fn({
+          ref: 'fakeParentPlaceholder5',
+          path: 'foo'
+        })).to.equal(null);
+      });
+      it('removes parent placeholder', function () {
+        var parent = dom.create(`<section data-uri="fakeParentPlaceholder6">
+          <div data-editable="foo">
+            <div>
+              <div class="kiln-placeholder"></div>
+            </div>
+          </div>
+        </section>`);
+
+        document.body.appendChild(parent);
+        expect(fn({
+          ref: 'fakeParentPlaceholder6',
+          path: 'foo'
+        })).to.not.equal(null);
+      });
+    });
+  });
+});

--- a/services/pane.js
+++ b/services/pane.js
@@ -8,6 +8,7 @@ var _ = require('lodash'),
   paneController = require('../controllers/pane'),
   newPagePaneController = require('../controllers/pane-new-page'),
   publishPaneController = require('../controllers/publish-pane'),
+  addComponentPaneController = require('../controllers/add-component-pane'),
   kilnHideClass = 'kiln-hide';
 
 /**
@@ -303,18 +304,21 @@ function addFilteredItems(items) {
 /**
  * open the add component pane
  * @param {array} components
- * @param {object} options
+ * @param {object} options to pass to controller (used for calling addComponent)
  */
 function openAddComponent(components, options) {
   var header = 'Add Component',
     inputEl = exports.getTemplate('.filtered-input-template'),
     itemsEl = addFilteredItems(components),
-    innerEl = document.createDocumentFragment();
+    innerEl = document.createDocumentFragment(),
+    el;
 
   innerEl.appendChild(inputEl);
   innerEl.appendChild(itemsEl);
-  open(header, innerEl);
-  // init dollar-slice controller for add-component
+  el = open(header, innerEl);
+  // init controller for add component pane
+  ds.controller('add-component-pane', addComponentPaneController);
+  ds.get('add-component-pane', el, options);
 }
 
 function takeOffEveryZig() {

--- a/services/pane.js
+++ b/services/pane.js
@@ -318,7 +318,7 @@ function openAddComponent(components, options) {
   el = open(header, innerEl);
   // init controller for add component pane
   ds.controller('add-component-pane', addComponentPaneController);
-  ds.get('add-component-pane', el, options);
+  ds.get('add-component-pane', el.querySelector('.kiln-toolbar-pane'), options);
 }
 
 function takeOffEveryZig() {

--- a/services/pane.js
+++ b/services/pane.js
@@ -4,6 +4,7 @@ var _ = require('lodash'),
   ds = require('dollar-slice'),
   state = require('./page-state'),
   site = require('./site'),
+  label = require('./label'),
   paneController = require('../controllers/pane'),
   newPagePaneController = require('../controllers/pane-new-page'),
   publishPaneController = require('../controllers/publish-pane'),
@@ -281,6 +282,41 @@ function openValidationErrors(validation) {
   open(header, innerEl);
 }
 
+function addFilteredItems(items) {
+  var wrapper = exports.getTemplate('.filtered-items-template'),
+    listEl = dom.find(wrapper, 'ul');
+
+  _.each(items, function (item) {
+    var itemEl = exports.getTemplate('.filtered-item-template'),
+      listItem = dom.find(itemEl, 'li');
+
+    // add component name and label to each list item
+    listItem.innerHTML = label(item);
+    listItem.setAttribute('data-item-name', item);
+    // add it to the list
+    listEl.appendChild(itemEl);
+  });
+
+  return wrapper;
+}
+
+/**
+ * open the add component pane
+ * @param {array} components
+ * @param {object} options
+ */
+function openAddComponent(components, options) {
+  var header = 'Add Component',
+    inputEl = exports.getTemplate('.filtered-input-template'),
+    itemsEl = addFilteredItems(components),
+    innerEl = document.createDocumentFragment();
+
+  innerEl.appendChild(inputEl);
+  innerEl.appendChild(itemsEl);
+  open(header, innerEl);
+  // init dollar-slice controller for add-component
+}
+
 function takeOffEveryZig() {
   var header = '<span class="ayb-header">HOW ARE YOU GENTLEMEN <em>!!</em></span>',
     messageEl = dom.create(`
@@ -305,4 +341,5 @@ module.exports.open = open;
 module.exports.openNewPage = openNewPage;
 module.exports.openPublish = openPublish;
 module.exports.openValidationErrors = openValidationErrors;
+module.exports.openAddComponent = openAddComponent;
 module.exports.takeOffEveryZig = takeOffEveryZig;

--- a/services/pane.test.js
+++ b/services/pane.test.js
@@ -326,5 +326,31 @@ describe(dirname, function () {
         expect(document.querySelectorAll('.pane-inner .errors li').length).to.equal(0);
       });
     });
+
+    describe('openAddComponent', function () {
+      var fn = lib[this.title],
+        sandbox;
+
+      beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+        sandbox.stub(ds);
+      });
+
+      afterEach(function () {
+        sandbox.restore();
+      });
+
+      it('opens a an add component pane', function () {
+        var options = {
+          field: { ref: null, path: null}, // parent data, passed to addComponent (we don't care about it here)
+          pane: document.createElement('div') // pane element, passed to addComponent (we don't care about it here)
+        };
+
+        lib.close();
+        fn(['foo', 'bar'], options);
+        expect(document.querySelector('.pane-header').innerHTML).to.equal('Add Component');
+        expect(document.querySelectorAll('.pane-inner li.filtered-item').length).to.equal(2); // 2 component buttons
+      });
+    });
   });
 });

--- a/services/pane.test.js
+++ b/services/pane.test.js
@@ -72,6 +72,9 @@ describe(dirname, function () {
       getTemplate.withArgs('.publish-error-message-template').returns(dom.create('<div>ERROR MESSAGE</div>'));
       getTemplate.withArgs('.publish-warning-message-template').returns(dom.create('<div>WARNING MESSAGE</div>'));
       getTemplate.withArgs('.publish-errors-template').returns(stubErrorsTemplate());
+      getTemplate.withArgs('.filtered-input-template').returns(dom.create('<input class="filtered-input" />'));
+      getTemplate.withArgs('.filtered-items-template').returns(dom.create('<div><ul class="filtered-items"></div>')); // wrapper divs to simulate doc fragments
+      getTemplate.withArgs('.filtered-item-template').returns(dom.create('<div><li class="filtered-item"></div>')); // wrapper divs to simulate doc fragments
     });
 
     afterEach(function () {
@@ -347,9 +350,9 @@ describe(dirname, function () {
         };
 
         lib.close();
-        fn(['foo', 'bar'], options);
+        fn(['foo'], options);
         expect(document.querySelector('.pane-header').innerHTML).to.equal('Add Component');
-        expect(document.querySelectorAll('.pane-inner li.filtered-item').length).to.equal(2); // 2 component buttons
+        expect(document.querySelectorAll('.pane-inner li.filtered-item').length).to.equal(1);
       });
     });
   });

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -338,7 +338,7 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
 }
 
 .kiln-toolbar-pane .filtered-item.active {
-  border-bottom-width: 2px;
+  border-bottom: 2px solid $blue;
 }
 
 @keyframes shake {

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -336,3 +336,7 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
   outline: none;
   transition: 200ms border-bottom-color ease-out;
 }
+
+.kiln-toolbar-pane .filtered-item.active {
+  border-bottom-width: 2px;
+}

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -340,3 +340,15 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
 .kiln-toolbar-pane .filtered-item.active {
   border-bottom-width: 2px;
 }
+
+@keyframes shake {
+  0%, 100% {transform: translateX(0);}
+  20%, 60% {transform: translateX(-5px);}
+  40%, 80% {transform: translateX(5px);}
+}
+
+.kiln-shake {
+  animation-name: shake;
+  animation-duration: 300ms;
+  animation-fill-mode: both;
+}

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -294,3 +294,45 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
   color: $green;
   margin: 4px 0; // vertically center with the icon (24px - 16px)
 }
+
+/* filtered item search pane (add component, possibly new page in the future) */
+.kiln-toolbar-pane .filtered-input {
+  @include input();
+
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.kiln-toolbar-pane .filtered-items {
+  margin: 0;
+  padding: 0;
+  position: relative;
+  width: 100%;
+}
+
+.kiln-toolbar-pane .filtered-item {
+  @include primary-text();
+
+  cursor: pointer;
+  line-height: 16px;
+  list-style: none;
+  margin: 0;
+  padding: 15px 0;
+  width: 100%;
+}
+
+.kiln-toolbar-pane .filtered-item.filtered {
+  display: none;
+}
+
+.kiln-toolbar-pane .filtered-item:not(.filtered) {
+  border-bottom: 1px solid $grey;
+  transition: 200ms border-bottom-color ease-out;
+}
+
+.kiln-toolbar-pane .filtered-item:focus {
+  border-bottom: 1px solid $blue;
+  outline: none;
+  transition: 200ms border-bottom-color ease-out;
+}

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -126,4 +126,18 @@
   <template class="publish-warning-message-template">
     <div class="warning-message">This page has some warnings. Please review before publishing.</div>
   </template>
+
+  <template class="filtered-input-template">
+    <input class="filtered-input" />
+  </template>
+
+  <template class="filtered-items-template">
+    <ul class="filtered-items">
+      {# filtered items get added using the .filtered-item-template below #}
+    </ul>
+  </template>
+
+  <template class="filtered-item-template">
+    <li class="filtered-item" tabindex="0"></li>
+  </template>
 {% endif %}


### PR DESCRIPTION
* no more big list of buttons!
* no more _two-clicks-when-you-can-only-add-one-component_ situations!
* [trello ticket](https://trello.com/c/mu4cKjZ2/322-add-component-to-list-updates)

![cff602c2-5c85-45dc-a946-e2bb3cf9fc41-476-000453d7ebd54c35](https://cloud.githubusercontent.com/assets/447522/15026282/aed0a0d0-120b-11e6-8576-97330d35195d.gif)

Now, when you hit the plus button, it will do one of two things:

* if there's a single component you're able to add, it'll just add it
* if there are multiple components you're able to add, it'll open up the add component pane

**Add Component Pane?**

Yeah! It's a searchable _and_ browseable list of components that you're able to add to the current component list. You can:

* type into the search box (autofocused by default) to filter the list
* type until a single component remains, then press <kbd>enter</kbd> to add it
* use <kbd>tab</kbd>/<kbd>shift + tab</kbd> or <kbd>↓</kbd>/<kbd>↑</kbd> to navigate the list
* if you have a list item focused, press <kbd>enter</kbd> to add it
* press <kbd>esc</kbd> or click the **X** at any time to exit the pane

The pane also provides a bunch of visual feedback!