### PR TITLE
run settings group name through label service

### DIFF
--- a/services/groups.js
+++ b/services/groups.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
-  references = require('./references');
+  references = require('./references'),
+  label = require('./label');
 
 /**
  * Given an array of fields, get an array of matching data.
@@ -65,7 +66,7 @@ function getSettingsGroup(ref, data) {
     value: getSettingsFields(data),
     _schema: {
       _display: 'settings',
-      _label: _.startCase(references.getComponentNameFromReference(ref)) + ' Settings',
+      _label: label(references.getComponentNameFromReference(ref)) + ' Settings',
       _name: 'settings'
     }
   };

--- a/services/pane.js
+++ b/services/pane.js
@@ -250,17 +250,20 @@ function addErrorsOrWarnings(errors, modifier) {
   return _.reduce(errors, function (el, error) {
     var errorEl = tpl.get('.publish-errors-template'),
       errorLabel = dom.find(errorEl, '.label'),
+      labelVal = _.get(error, 'rule.label'),
+      descVal = _.get(error, 'rule.description'),
       errorDescription = dom.find(errorEl, '.description'),
       list = dom.find(errorEl, '.errors');
 
     // add rule label if it exists
-    if (errorLabel && _.get(error, 'rule.label')) {
-      errorLabel.innerHTML = error.rule.label + ':';
+    if (errorLabel) {
+      errorLabel.innerHTML = labelVal ? `${labelVal}:` : 'There was a problem:';
+      // note the colon after the label, hence using a ternary operator
     }
 
     // add rule description if it exists
-    if (errorDescription && _.get(error, 'rule.description')) {
-      errorDescription.innerHTML = error.rule.description;
+    if (errorDescription) {
+      errorDescription.innerHTML = descVal || 'Please see below for details';
     }
 
     // add each place where the error/warning occurs


### PR DESCRIPTION
[trello ticket](https://trello.com/c/rAzsvTiG/341-double-check-label-service-in-component-settings-form-kiln)

automatically created `settings` groups should be labeled using the `label` service. this changes the settings form title so e.g. "Clay Tweet Settings" becomes "Tweet Settings"