### PR TITLE
added datepicker

### DIFF
--- a/behaviors/text.js
+++ b/behaviors/text.js
@@ -150,7 +150,7 @@ module.exports = function (result, args) {
           el.value = moment(observer.value()).format(firefoxDateFormat);
           datepicker.init(el, { onChange: function (date) {
             // when the datepicker changes, convert it back to ISO format
-            observer.setValue(moment(date).utc().format());
+            observer.setValue(moment(date).toISOString());
           }});
         } else {
           // use iso format

--- a/behaviors/text.js
+++ b/behaviors/text.js
@@ -13,7 +13,8 @@ var dom = require('@nymag/dom'),
     'search', // unsupported, not needed for input
     'submit' // unsupported form-level input (i.e. we already have submit buttons)
   ],
-  firefoxDateFormat = 'YYYY-MM-DD hh:mm A';
+  firefoxDateFormat = 'YYYY-MM-DD hh:mm A',
+  defaultDateFormat = 'YYYY-MM-DDThh:mm';
 
 /**
  * get attribute value of boolean fields
@@ -145,15 +146,24 @@ module.exports = function (result, args) {
         var observer = this.observer;
 
         // when instantiating, convert from the ISO format (what we save) to firefox's format (what the datepicker needs)
-        el.value = moment(observer.value()).format(firefoxDateFormat);
-        datepicker.init(el, { onChange: function (date) {
-          // when the datepicker changes, convert it back to ISO format
-          observer.setValue(moment(date).utc().format());
-        }});
+        if (!datepicker.hasNativePicker()) {
+          el.value = moment(observer.value()).format(firefoxDateFormat);
+          datepicker.init(el, { onChange: function (date) {
+            // when the datepicker changes, convert it back to ISO format
+            observer.setValue(moment(date).utc().format());
+          }});
+        } else {
+          // use iso format
+          el.value = moment(observer.value()).format(defaultDateFormat);
+        }
       },
       routine: function (el, value) {
         // every time the data updates, display the NEW data in firefox's format
-        el.value = moment(value).format(firefoxDateFormat);
+        if (!datepicker.hasNativePicker()) {
+          el.value = moment(value).format(firefoxDateFormat);
+        } else {
+          el.value = moment(value).format(defaultDateFormat);
+        }
       }
     };
   }

--- a/behaviors/text.js
+++ b/behaviors/text.js
@@ -1,5 +1,7 @@
 var dom = require('@nymag/dom'),
   _ = require('lodash'),
+  moment = require('moment'),
+  datepicker = require('../services/field-helpers/datepicker'),
   invalidTypes = [
     'button', // use other behaviors, e.g. segmented-button
     'checkbox', // use checkbox or checkbox-group behaviors
@@ -10,7 +12,8 @@ var dom = require('@nymag/dom'),
     'reset', // unsupported form-level input
     'search', // unsupported, not needed for input
     'submit' // unsupported form-level input (i.e. we already have submit buttons)
-  ];
+  ],
+  firefoxDateFormat = 'YYYY-MM-DD hh:mm A';
 
 /**
  * get attribute value of boolean fields
@@ -71,6 +74,18 @@ function addStep(args) {
 }
 
 /**
+ * add datepicker binder if it's a date input
+ * @param {string} name
+ * @param {string} type
+ * @returns {string}
+ */
+function addDateBinder(name, type) {
+  if (_.includes(['datetime-local', 'date', 'time'], type)) {
+    return `rv-datepicker="${name}.data.value"`;
+  }
+}
+
+/**
  * Replace result.el with input.
  * @param {{name: string, bindings: {}}} result
  * @param {{}} args   defined in detail below:
@@ -109,6 +124,7 @@ module.exports = function (result, args) {
           class="input-text"
           rv-field="${name}"
           type="${type}"
+          ${addDateBinder(name, type)}
           ${addStep(args)}
           ${addAutocomplete(args)}
           ${addAutocapitalize(args)}
@@ -120,6 +136,27 @@ module.exports = function (result, args) {
           rv-value="${name}.data.value" />
       </label>
     `);
+
+  // if it's a date input, init datepicker for non-native browsers
+  if (_.includes(['datetime-local', 'date', 'time'], type)) {
+    result.binders.datepicker = {
+      publish: true,
+      bind: function (el) {
+        var observer = this.observer;
+
+        // when instantiating, convert from the ISO format (what we save) to firefox's format (what the datepicker needs)
+        el.value = moment(observer.value()).format(firefoxDateFormat);
+        datepicker.init(el, { onChange: function (date) {
+          // when the datepicker changes, convert it back to ISO format
+          observer.setValue(moment(date).utc().format());
+        }});
+      },
+      routine: function (el, value) {
+        // every time the data updates, display the NEW data in firefox's format
+        el.value = moment(value).format(firefoxDateFormat);
+      }
+    };
+  }
 
   result.el = textField;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var gulp = require('gulp'),
   cssmin = require('gulp-cssmin'),
   prefixOptions = { browsers: ['last 2 versions', 'ie >= 9', 'ios >= 7', 'android >= 4.4.2'] },
   stylesGlob = [
+    'node_modules/flatpickr/dist/flatpickr.min.css',
     'styleguide/*.scss',
     'styleguide/*.css',
     'behaviors/*.scss',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dollar-slice": "^2.1.0",
     "domify": "^1.3.3",
     "dragula": "^3.5.4",
+    "flatpickr": "^1.8.4",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.0.1",
     "gulp-concat": "^2.6.0",

--- a/services/field-helpers/datepicker.js
+++ b/services/field-helpers/datepicker.js
@@ -1,0 +1,64 @@
+// this is a tiny little service that instantiates date pickers for browsers that
+// don't natively support them
+var flatpickr = require('flatpickr'),
+  _ = require('lodash');
+
+/**
+ * do user agent check to determine if the current browser supports native date pickers
+ * note: we need to do the UA sniffing because not all browsers that support
+ * <input type="date|time|datetime-local|etc"> actually use the native picker
+ * (here's looking at you, Firefox (ง •̀_•́)ง)
+ * @returns {boolean}
+ */
+function hasNativePicker() {
+  // note:
+  // IE11 returns undefined for window.chrome
+  // Opera 30 outputs true for window.chrome
+  // IE Edge outputs to true for window.chrome
+  var isChromium = window.chrome,
+    winNav = window.navigator,
+    vendorName = winNav.vendor,
+    isOpera = winNav.userAgent.indexOf('OPR') > -1,
+    isIEedge = winNav.userAgent.indexOf('Edge') > -1,
+    isIOSChrome = !!winNav.userAgent.match('CriOS'),
+    isMobileSafari = !!winNav.userAgent.match(/(iPod|iPhone|iPad)/) && !!winNav.userAgent.match(/AppleWebKit/),
+    isDesktopChrome = isChromium !== null && isChromium !== undefined && vendorName === 'Google Inc.' && isOpera == false && isIEedge == false;
+
+  return isIOSChrome || isDesktopChrome || isMobileSafari;
+}
+
+/**
+ * instantiate a non-native datepicker on an element
+ * @param {Element} el
+ * @param {object} [options] get merged with type-specific options
+ * @returns {object|undefined}
+ */
+function init(el, options) {
+  // flatpickr inits itself onto selector rather than an element, so add a random
+  // class to the element passed in
+  var type = el.getAttribute('type'),
+    enableTime, noCalendar, finalOptions; // options that change depending on input type
+
+
+  if (type === 'datetime-local') {
+    enableTime = true;
+    noCalendar = false;
+  } else if (type === 'date') {
+    enableTime = false;
+    noCalendar = false;
+  } else if (type === 'time') {
+    enableTime = true;
+    noCalendar = true;
+  } else {
+    return; // don't init a datepicker for any other type of input
+  }
+
+  // merge passed-in options with type-specific options
+  finalOptions = _.assign({enableTime: enableTime, noCalendar: noCalendar}, options);
+
+  if (!hasNativePicker()) {
+    return flatpickr(el, finalOptions);
+  }
+}
+
+module.exports.init = init;

--- a/services/field-helpers/datepicker.js
+++ b/services/field-helpers/datepicker.js
@@ -34,11 +34,8 @@ function hasNativePicker() {
  * @returns {object|undefined}
  */
 function init(el, options) {
-  // flatpickr inits itself onto selector rather than an element, so add a random
-  // class to the element passed in
   var type = el.getAttribute('type'),
     enableTime, noCalendar, finalOptions; // options that change depending on input type
-
 
   if (type === 'datetime-local') {
     enableTime = true;

--- a/services/field-helpers/datepicker.js
+++ b/services/field-helpers/datepicker.js
@@ -22,7 +22,7 @@ function hasNativePicker() {
     isIEedge = winNav.userAgent.indexOf('Edge') > -1,
     isIOSChrome = !!winNav.userAgent.match('CriOS'),
     isMobileSafari = !!winNav.userAgent.match(/(iPod|iPhone|iPad)/) && !!winNav.userAgent.match(/AppleWebKit/),
-    isDesktopChrome = isChromium !== null && isChromium !== undefined && vendorName === 'Google Inc.' && isOpera == false && isIEedge == false;
+    isDesktopChrome = isChromium !== null && isChromium !== undefined && vendorName === 'Google Inc.' && isOpera === false && isIEedge === false;
 
   return isIOSChrome || isDesktopChrome || isMobileSafari;
 }

--- a/services/field-helpers/datepicker.js
+++ b/services/field-helpers/datepicker.js
@@ -61,4 +61,5 @@ function init(el, options) {
   }
 }
 
+module.exports.hasNativePicker = hasNativePicker;
 module.exports.init = init;

--- a/services/pane.js
+++ b/services/pane.js
@@ -119,14 +119,29 @@ function createPublishMessages(res) {
 }
 
 /**
+ * get scheduled date
+ * @param {object} res
+ * @param {boolean} [res.scheduled]
+ * @param {string} [res.scheduledAt]
+ * @returns {object}
+ */
+function getScheduledValues(res) {
+  var at = res.scheduled ? moment(res.scheduledAt) : moment(),
+    date = at.format('YYYY-MM-DD'),
+    time = at.format('HH:mm');
+
+  return { date, time };
+}
+
+/**
  * create actions for the publish pane, depending on the state
  * @param {object} res
  * @returns {Element}
  */
 function createPublishActions(res) {
   const actions = tpl.get('.publish-actions-template'),
-    today = moment().format('YYYY-MM-DD'),
-    now = moment().format('HH:mm');
+    val = getScheduledValues(res);
+
   let scheduleDate, scheduleTime, unpublish, unschedule;
 
   // set date and time
@@ -135,14 +150,14 @@ function createPublishActions(res) {
     scheduleTime = dom.find(actions, '#schedule-time');
 
     if (scheduleDate) {
-      scheduleDate.setAttribute('min', today);
-      scheduleDate.setAttribute('value', today);
-      scheduleDate.setAttribute('placeholder', today);
+      scheduleDate.setAttribute('min', val.date);
+      scheduleDate.setAttribute('value', val.date);
+      scheduleDate.setAttribute('placeholder', val.date);
     }
 
     if (scheduleTime) {
-      scheduleTime.setAttribute('value', now);
-      scheduleTime.setAttribute('placeholder', now);
+      scheduleTime.setAttribute('value', val.time);
+      scheduleTime.setAttribute('placeholder', val.time);
     }
 
     // init datepicker for non-native browsers

--- a/services/pane.js
+++ b/services/pane.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
   site = require('./site'),
   label = require('./label'),
   tpl = require('./tpl'),
+  datepicker = require('./field-helpers/datepicker'),
   paneController = require('../controllers/pane'),
   newPagePaneController = require('../controllers/new-page-pane'),
   publishPaneController = require('../controllers/publish-pane'),
@@ -143,6 +144,10 @@ function createPublishActions(res) {
       scheduleTime.setAttribute('value', now);
       scheduleTime.setAttribute('placeholder', now);
     }
+
+    // init datepicker for non-native browsers
+    datepicker.init(scheduleDate);
+    datepicker.init(scheduleTime);
   }
 
   // unscheduling

--- a/styleguide/_layers.scss
+++ b/styleguide/_layers.scss
@@ -13,3 +13,7 @@
 @mixin overlay-layer {
   z-index: 1020;
 }
+
+@mixin datepicker-layer {
+  z-index: 1030; // must be above toolbar AND overlays
+}

--- a/styleguide/datepicker.scss
+++ b/styleguide/datepicker.scss
@@ -1,0 +1,24 @@
+@import 'layers';
+@import 'typography';
+
+.flatpickr-wrapper.inline .flatpickr-calendar,
+.flatpickr-wrapper.open .flatpickr-calendar {
+  @include datepicker-layer();
+
+  // not the full kiln-copy (no sizes, overrides, etc)
+  font-family: $system-fonts;
+}
+
+.flatpickr-month {
+  padding: 6px 10px 4px;
+}
+
+.flatpickr-weekdays {
+  font-size: 11.5px;
+}
+
+.flatpickr-hour,
+.flatpickr-minute,
+.flatpickr-am-pm {
+  font-size: 14px;
+}

--- a/styleguide/datepicker.scss
+++ b/styleguide/datepicker.scss
@@ -1,5 +1,6 @@
 @import 'layers';
 @import 'typography';
+@import 'colors';
 
 .flatpickr-wrapper.inline .flatpickr-calendar,
 .flatpickr-wrapper.open .flatpickr-calendar {
@@ -21,4 +22,11 @@
 .flatpickr-minute,
 .flatpickr-am-pm {
   font-size: 14px;
+}
+
+// use our blue for selected date
+.flatpickr-day.selected,
+.flatpickr-day.selected:hover {
+  background: $blue none repeat scroll 0% 0%;
+  border-color: $blue;
 }

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -145,7 +145,8 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
 }
 
 .kiln-toolbar-pane .schedule-input,
-.kiln-toolbar-pane .preview-input {
+.kiln-toolbar-pane .preview-input,
+.kiln-toolbar-pane .kiln-input { // generic input class, used by flatpickr
   @include input();
 
   cursor: initial;


### PR DESCRIPTION
On browsers other than Chrome, Mobile Chrome, and Mobile Safari, there is no native picker for the `datetime-local`, `date`, or `time` input types (even though those browsers report that they "support" them). Thus, it is necessary to add our own picker.

The simplest one (with no dependencies, and a very usable styling) is [flatpickr](https://chmln.github.io/flatpickr/). This is what it looks like for `datetime-local`, `date`, and `time`, respectively:

<img width="723" alt="screen shot 2016-06-10 at 12 29 34" src="https://cloud.githubusercontent.com/assets/447522/15971519/70a3f3f2-2f07-11e6-931a-cb41a95b528a.png">

![screen shot 2016-06-09 at 5 13 11 pm](https://cloud.githubusercontent.com/assets/447522/15971526/7bb3518e-2f07-11e6-8c5c-b2dbae512f2a.png)

![screen shot 2016-06-09 at 5 13 02 pm](https://cloud.githubusercontent.com/assets/447522/15971531/7fa71866-2f07-11e6-9301-0e8e99007827.png)
