### PR TITLE
catch html trying to be pasted as escaped strings

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -132,7 +132,8 @@ function createEditor(field, buttons) {
       ],
       preCleanReplacements: [
         [/<h[1-9]>/ig, '<h2>'],
-        [/<\/h[1-9]>/ig, '</h2>'] // force all headers to the same level
+        [/<\/h[1-9]>/ig, '</h2>'], // force all headers to the same level
+        [/&lt;(.*?)&gt;/ig, ''] // catch any html trying to be sent in as escaped strings
       ]
     },
     anchor: {

--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -131,9 +131,10 @@ function createEditor(field, buttons) {
         'iframe'
       ],
       preCleanReplacements: [
+        [/&lt;(.*?)&gt;/ig, '<$1>'], // catch any html trying to be sent in as escaped strings,
+        // thus allowing cleanTags (above) or text-model to manage them
         [/<h[1-9]>/ig, '<h2>'],
-        [/<\/h[1-9]>/ig, '</h2>'], // force all headers to the same level
-        [/&lt;(.*?)&gt;/ig, ''] // catch any html trying to be sent in as escaped strings
+        [/<\/h[1-9]>/ig, '</h2>'] // force all headers to the same level
       ]
     },
     anchor: {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "konami-js": "^0.0.2",
     "lodash": "^3.8.0",
     "lodash-deep": "^1.6.0",
-    "medium-editor": "^5.16.1",
+    "medium-editor": "^5.21.0",
     "moment": "^2.10.6",
     "nprogress": "^0.2.0",
     "responsive-filenames": "^1.2.0",


### PR DESCRIPTION
I noticed, when diagnosing [this trello ticket](https://trello.com/c/NlJAHZ3U/42-bug-facebook-embed), that people were pasting iframes into paragraphs where they shouldn't be able to. `medium-editor` cleans pasted tags (including iframes), but will miss those tags if they're pasted in as escaped strings (e.g. `&lt;iframe&gt;`). This catches any escaped tags and removes them when pasting, but allows real tags to be pasted like normal.