### PR TITLE
Added `flex` CSS

### DIFF
--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -298,4 +298,5 @@ $layout-parent-bg-color: $purple-25;
 .component-list-inner {
   display: inherit;
   flex-flow: row wrap;
+  flex: 1 1 100%;
 }


### PR DESCRIPTION
Adding in `flex` so that the `component-list-inner` can grow/shrink within its container. It will now always fill its container's width.