### PR TITLE
Allow placeholder to display values.

### DIFF
--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -150,18 +150,16 @@ Placeholders can display the value of a field, which is useful for components no
 videoId:
   _placeholder:
     text: Video Id ${videoId}
-    height: 100px
     permanent: true
 
-# field-group with values in placeholder text
+# group with values in placeholder text
 _groups:
-  settings:
+  group1:
     fields:
       - name
       - description
     _placeholder:
       text: Ad Unit ${name} ${description}
-      height: 100px
       permanent: true
 ```
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -143,7 +143,7 @@ adName:
     permanent: true
 ```
 
-Placeholders can display the value of a field, which is useful for components not visible during edit mode, e.g. third-party JavaScript. The syntax for displaying a value in the placeholder text is `${propertyName}`, which is similar to JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). Note that `permanent: true` must be set. Example schemas:
+Placeholders can display the value of a field, which is useful for components not visible during edit mode, e.g. third-party JavaScript. The syntax for displaying a value in the placeholder text is `${fieldName}`, which is similar to JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). Note that `permanent: true` must be set. Example schemas:
 
 ```yaml
 # single field with value in placeholder text

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -143,6 +143,28 @@ adName:
     permanent: true
 ```
 
+Placeholders can display the value of a field, which is useful for components not visible during edit mode, e.g. third-party JavaScript. The syntax for displaying a value in the placeholder text is `${propertyName}`, which is similar to JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). Note that `permanent: true` must be set. Example schemas:
+
+```yaml
+# single field with value in placeholder text
+videoId:
+  _placeholder:
+    text: Video Id ${videoId}
+    height: 100px
+    permanent: true
+
+# field-group with values in placeholder text
+_groups:
+  settings:
+    fields:
+      - name
+      - description
+    _placeholder:
+      text: Ad Unit ${name} ${description}
+      height: 100px
+      permanent: true
+```
+
 Placeholders will display when you add `data-editable="fieldName"` in your component's template. If you're using a permanent placeholder and/or you don't want the user to click through and open a form, you can specify `data-placeholder="fieldName"` instead.
 
 When deciding how to add placeholders, keep these things in mind:

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -39,7 +39,7 @@ function getFieldVal(path, data, fieldName) {
  * @returns {Function}
  */
 function replaceFieldName(path, data) {
-  return (match, fieldName) => getFieldVal(path, data, fieldName.trim());
+  return (match, fieldName) => getFieldVal(path, data, fieldName);
 }
 
 /**
@@ -54,7 +54,7 @@ function replaceFieldName(path, data) {
 function getPlaceholderText(path, data) {
   var schema = data._schema,
     placeholder = schema[references.placeholderProperty],
-    propNamePattern = /\${(\w+)}/ig; // allows property value in text, e.g. 'The value is ${propName}'
+    propNamePattern = /\${\s*(\w+)\s*}/ig; // allows property value in text, e.g. 'The value is ${propName}'
 
   if (_.isObject(placeholder) && placeholder.text) {
     return placeholder.text.replace(propNamePattern, replaceFieldName(path, data));

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -54,7 +54,7 @@ function replacePropVal(path, data) {
 function getPlaceholderText(path, data) {
   var schema = data._schema,
     placeholder = schema[references.placeholderProperty],
-    propNamePattern = new RegExp(/\$\{([^\}]+)}/ig); // allows property value in text, e.g. 'The value is ${propName}'
+    propNamePattern = /\$\{(\w+)\}/ig; // allows property value in text, e.g. 'The value is ${propName}'
 
   if (_.isObject(placeholder) && placeholder.text) {
     return placeholder.text.replace(propNamePattern, replacePropVal(path, data));

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -9,10 +9,10 @@ var _ = require('lodash'),
  *
  * @param {Array} groupItems
  * @param {string} propName
- * @returns {object}
+ * @returns {object|undefined}
  */
 function findPropInFieldGroup(groupItems, propName) {
-  return _.find(groupItems, groupProp => _.get(groupProp, '_schema._name') === propName) || null;
+  return _.find(groupItems, groupProp => _.get(groupProp, '_schema._name') === propName);
 }
 
 /**
@@ -25,7 +25,7 @@ function findPropInFieldGroup(groupItems, propName) {
 function getPropVal(path, data, propName) {
   var value = 'value';
 
-  return String( // always return a string
+  return new String( // always return a string; we cannot rely on the `toString` method as it can throw errors
     _.get(
       propName === path ? data : findPropInFieldGroup(data[value], propName), // single property or field-group
       value
@@ -54,7 +54,7 @@ function replacePropVal(path, data) {
 function getPlaceholderText(path, data) {
   var schema = data._schema,
     placeholder = schema[references.placeholderProperty],
-    propNamePattern = /\$\{(\w+)\}/ig; // allows property value in text, e.g. 'The value is ${propName}'
+    propNamePattern = /\${(\w+)}/ig; // allows property value in text, e.g. 'The value is ${propName}'
 
   if (_.isObject(placeholder) && placeholder.text) {
     return placeholder.text.replace(propNamePattern, replacePropVal(path, data));

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -54,10 +54,10 @@ function replaceFieldName(path, data) {
 function getPlaceholderText(path, data) {
   var schema = data._schema,
     placeholder = schema[references.placeholderProperty],
-    propNamePattern = /\${\s*(\w+)\s*}/ig; // allows property value in text, e.g. 'The value is ${propName}'
+    fieldNamePattern = /\${\s*(\w+)\s*}/ig; // allows field value in text, e.g. 'The value is ${fieldName}'
 
   if (_.isObject(placeholder) && placeholder.text) {
-    return placeholder.text.replace(propNamePattern, replaceFieldName(path, data));
+    return placeholder.text.replace(fieldNamePattern, replaceFieldName(path, data));
   } else {
     return label(path, schema);
   }

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -6,28 +6,28 @@ var _ = require('lodash'),
   addComponentHandler = require('../services/components/add-component-handler');
 
 /**
- *
- * @param {Array} groupItems
- * @param {string} propName
+ * given an array of fields, find the field that matches a certain name
+ * @param {string} fieldName
+ * @param {Array} groupFields
  * @returns {object|undefined}
  */
-function findPropInFieldGroup(groupItems, propName) {
-  return _.find(groupItems, groupProp => _.get(groupProp, '_schema._name') === propName);
+function getFieldFromGroup(fieldName, groupFields) {
+  return _.find(groupFields, field => _.get(field, '_schema._name') === fieldName);
 }
 
 /**
- * get the property value
+ * get the field's value
  * @param {string} path
  * @param {object} data
- * @param {string} propName
+ * @param {string} fieldName
  * @returns {String}
  */
-function getPropVal(path, data, propName) {
+function getFieldVal(path, data, fieldName) {
   var value = 'value';
 
   return new String( // always return a string; we cannot rely on the `toString` method as it can throw errors
     _.get(
-      propName === path ? data : findPropInFieldGroup(data[value], propName), // single property or field-group
+      fieldName === path ? data : getFieldFromGroup(fieldName, data[value]), // single field or group
       value
     ) || ''); // default to empty string
 }
@@ -38,8 +38,8 @@ function getPropVal(path, data, propName) {
  * @param {object} data
  * @returns {Function}
  */
-function replacePropVal(path, data) {
-  return (match, propName) => getPropVal(path, data, propName.trim());
+function replaceFieldName(path, data) {
+  return (match, fieldName) => getFieldVal(path, data, fieldName.trim());
 }
 
 /**
@@ -57,7 +57,7 @@ function getPlaceholderText(path, data) {
     propNamePattern = /\${(\w+)}/ig; // allows property value in text, e.g. 'The value is ${propName}'
 
   if (_.isObject(placeholder) && placeholder.text) {
-    return placeholder.text.replace(propNamePattern, replacePropVal(path, data));
+    return placeholder.text.replace(propNamePattern, replaceFieldName(path, data));
   } else {
     return label(path, schema);
   }
@@ -109,23 +109,6 @@ function isFieldEmpty(data) {
   }
 
   return !_.isBoolean(value) && !_.isNumber(value) && _.isEmpty(value);
-}
-
-/**
- * given an array of fields, find the field that matches a certain name
- * @param {string} name
- * @param {array} value
- * @throws {Error} if no field found (this is a programmer error)
- * @returns {object}
- */
-function getFieldFromGroup(name, value) {
-  var possibleField = _.find(value, function (field) {
-    var currentField = _.get(field, '_schema._name');
-
-    return name === currentField;
-  });
-
-  return possibleField;
 }
 
 /**

--- a/decorators/placeholder.test.js
+++ b/decorators/placeholder.test.js
@@ -30,16 +30,67 @@ describe(dirname, function () {
         // but we don't anymore.
         // if you want to specify placeholder text, put it in the `text` property
         // e.g. _placeholder: { text: 'some string of text' }
-        expect(fn(mockName, {_placeholder: 'Bar'})).to.equal('Foo Bar');
+        expect(fn(mockName, {_schema: {_placeholder: 'Bar'}})).to.equal('Foo Bar');
       });
 
       it('uses placeholder text if it exists', function () {
-        expect(fn(mockName, {_placeholder: {text: 'Baz'}})).to.equal('Baz');
+        expect(fn(mockName, {_schema: {_placeholder: {text: 'Baz'}}})).to.equal('Baz');
       });
 
       it('falls back to label if no placeholder text', function () {
-        expect(fn(mockName, {_placeholder: 'true'})).to.equal('Foo Bar');
-        expect(fn(mockName, {_placeholder: true})).to.equal('Foo Bar');
+        expect(fn(mockName, {_schema: {_placeholder: 'true'}})).to.equal('Foo Bar');
+        expect(fn(mockName, {_schema: {_placeholder: true}})).to.equal('Foo Bar');
+      });
+
+      it('uses property value in placeholder text if value exists', function () {
+        var mockData = {
+          _schema: {
+            _placeholder: {
+              text: 'Value is ${mockProp}'
+            },
+            _name: 'mockProp'
+          },
+          value: 'some value'
+        };
+
+        expect(fn('mockProp', mockData)).to.equal('Value is some value');
+      });
+
+      it('uses values from a group in placeholder text if values exist', function () {
+        var mockGroupData = {
+          value: [{
+            _schema: {
+              _name: 'propA'
+            }, value: 'some value'
+          }, {
+            _schema: {
+              _name: 'propB'
+            }, value: 'another value'
+          }],
+          _schema: {
+            _name: 'mockGroup',
+            fields: ['propA', 'propB'],
+            _placeholder: {
+              text: 'A is ${propA} and B is ${propB}'
+            }
+          }
+        };
+
+        expect(fn('mockGroup', mockGroupData)).to.equal('A is some value and B is another value');
+      });
+
+      it('uses empty string in placeholder text if value does not exist', function () {
+        var mockData = {
+          _schema:{
+            _placeholder: {
+              text: 'Value is ${mockProp}'
+            },
+            _name: 'mockProp'
+          },
+          value: undefined
+        };
+
+        expect(fn('mockProp', mockData)).to.equal('Value is ');
       });
     });
 


### PR DESCRIPTION
This PR allows a placeholder to display the field value or any value within a field-group, which is useful for components not visible during edit mode, e.g. third-party JavaScript.

The syntax, `${propertyName}`,  is similar to JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).

Example field-group schema:

```
_groups:
  settings:
    fields:
      - name
      - description
    _placeholder:
      text: Ad Unit ${name} ${description}
      height: 100px
      permanent: true
```

Example field schema:

```
videoId:
  _label: Video ID
  _display: inline
  _placeholder:
    text: Ooyala Video Id ${videoId}
    height: 100px
    permanent: true
  _has:
    - text
    - label
    - required
    -
      fn: description
      value: Please paste the ID of your video here from Ooyala Backlot.
```