### PR TITLE
multi-field placeholders

### DIFF
--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -215,7 +215,7 @@ _groups:
 
 When Kiln generates a form for a group, the `_display` (and `_placeholder`) properties of the individual fields are ignored. This means that you don't have to specify those properties in your fields if they're only used in groups (rather than referenced directly).
 
-If you add a `_placeholder` to a group, you _must_ either make it permanent (with `permanent: true`) _or_ specify a field it should check (with `ifEmpty: fieldName`). It will display the placeholder when that field is empty.
+If you add a `_placeholder` to a group, you _must_ either make it permanent (with `permanent: true`) _or_ specify fields it should check (with `ifEmpty: fieldName`). It will display the placeholder when that field is empty.
 
 ```yaml
 _groups:
@@ -229,6 +229,18 @@ _groups:
       text: Click here to add stuff
       height: 40px
       ifEmpty: title
+```
+
+Placeholders may check two different fields, and run a logical comparison on them. This is handy for components with editable links, as you'll usually want to display a placeholder when _either_ the url and the link text are empty. Comparators are case-insensitive, and you can use `AND`, `OR`, or `XOR`.
+
+```yaml
+_groups:
+  link:
+    fields:
+      - url
+      - text
+    _placeholder:
+      ifEmpty: url OR text
 ```
 
 #### Settings Group

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -231,7 +231,7 @@ _groups:
       ifEmpty: title
 ```
 
-Placeholders may check two different fields, and run a logical comparison on them. This is handy for components with editable links, as you'll usually want to display a placeholder when _either_ the url and the link text are empty. Comparators are case-insensitive, and you can use `AND`, `OR`, or `XOR`.
+Placeholders may check two different fields with a logical operator. This is handy for components with editable links, as you'll usually want to display a placeholder when _either_ the url or the link text are empty. Operators are case-insensitive, and you can use `AND`, `OR`, or `XOR`.
 
 ```yaml
 _groups:

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -125,13 +125,13 @@ function isFieldAndEmpty(name, data) {
 }
 
 /**
- * compare multiple fields to see if they're empty
+ * compare two fields to see if they're empty
  * comparators are case insensitive, so AND, and, OR, or, etc work
  * @param {array} tokens must have 3 items
  * @param {object} data
  * @returns {boolean}
  */
-function compareMultipleFields(tokens, data) {
+function compareTwoFields(tokens, data) {
   var isFirstEmpty = isFieldAndEmpty(tokens[0], data),
     comparator = tokens[1].toLowerCase(), // comparator is case-insensitive
     isSecondEmpty = isFieldAndEmpty(tokens[2], data);
@@ -169,7 +169,7 @@ function isGroupEmpty(data) {
     // check multiple fields
     // note: for now this is limited to checking two fields
     // e.g. foo AND bar, foo OR bar, foo XOR bar
-    return compareMultipleFields(tokens, data);
+    return compareTwoFields(tokens, data);
   } else {
     // someone messed something up in their ifEmpty statement, let them know
     throw new Error('Cannot check if fields are empty: ' + ifEmpty);

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -113,12 +113,13 @@ function isFieldEmpty(data) {
 
 /**
  * determine if a group is empty
- * by looking at the field denoted by the `ifEmpty` property (in the placeholder object)
+ * by looking at the field(s) denoted by the `ifEmpty` property (in the placeholder object)
  * @param {obejct} data
  * @returns {boolean}
  */
 function isGroupEmpty(data) {
-  var fieldName = _.get(data, '_schema._placeholder.ifEmpty'),
+  var ifEmpty = _.get(data, '_schema._placeholder.ifEmpty'),
+  fieldNames
     field = getFieldFromGroup(fieldName, data.value),
     isField = _.has(field, '_schema.' + references.fieldProperty);
 

--- a/decorators/placeholder.test.js
+++ b/decorators/placeholder.test.js
@@ -322,6 +322,267 @@ describe(dirname, function () {
 
         expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'title'})).to.equal(false);
       });
+
+      it('returns true if group with ifEmpty pointing to two empty fields with AND', function () {
+        var title = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title AND desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(true);
+      });
+
+      it('returns false if group with ifEmpty pointing to one empty field and one non-empty field with AND', function () {
+        var title = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title AND desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(false);
+      });
+
+      it('returns false if group with ifEmpty pointing to two non-empty fields with AND', function () {
+        var title = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title AND desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(false);
+      });
+
+      it('returns true if group with ifEmpty pointing to two empty fields with OR', function () {
+        var title = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title OR desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(true);
+      });
+
+      it('returns true if group with ifEmpty pointing to one empty field and one non-empty field with OR', function () {
+        var title = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title OR desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(true);
+      });
+
+      it('returns false if group with ifEmpty pointing to two non-empty fields with OR', function () {
+        var title = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title OR desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(false);
+      });
+
+      it('returns false if group with ifEmpty pointing to two empty fields with XOR', function () {
+        var title = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title XOR desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(false);
+      });
+
+      it('returns true if group with ifEmpty pointing to one empty field and one non-empty field with XOR', function () {
+        var title = {
+            value: '',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title XOR desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(true);
+      });
+
+      it('returns false if group with ifEmpty pointing to two non-empty fields with XOR', function () {
+        var title = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'title'
+            }
+          },
+          desc = {
+            value: 'asdf',
+            _schema: {
+              _has: 'text',
+              _name: 'desc'
+            }
+          },
+          stubData = {
+            value: [title, desc],
+            _schema: {
+              fields: ['title', 'desc'],
+              _placeholder: {
+                ifEmpty: 'title XOR desc'
+              },
+              _name: 'titlegroup'
+            }
+          };
+
+        expect(fn(stubNode(), {data: stubData, ref: 'fakeRef', path: 'titlegroup'})).to.equal(false);
+      });
     });
 
     describe('handler', function () {


### PR DESCRIPTION
Allow placeholders to check **TWO FIELDS** rather than just one. Great for groups, especially link `url` + `text` pairs. Use natural language to specify which properties to check.

```
field1 AND field2
field1 or field2
field1 XOR field2
```

Fixes #490

_Note:_ We're not allowing an arbitrary number of fields because that would require writing a [recursive descent parser](http://blog.oleganza.com/post/106246432/recursive-descent-parser-in-javascript).