### PR TITLE
ignore non-code files

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,8 +22,12 @@ settings = {
         presets: ['es2015']
       }),
       istanbul({
-        ignore: ['**/node_modules/**'],
-        defaultIgnore: true
+        ignore: [
+          '**/*.test.js',
+          '**/*.md',
+          '**/*.scss'
+        ],
+        defaultIgnore: true // ignores node_modules, /test/, json files
       })
     ]
   },


### PR DESCRIPTION
looks like we weren't setting up our istanbul `ignore` array properly