### PR TITLE
All components should be treated as editable

### DIFF
--- a/controllers/component-edit.js
+++ b/controllers/component-edit.js
@@ -38,18 +38,6 @@ function ComponentEdit() {
   }
 
   /**
-   * find out if component is editable or contains editable children
-   * @param  {Element}  el component element
-   * @return {Boolean}
-   */
-  function isComponentEditable(el) {
-    return el.hasAttribute(editableAttr) ||
-      el.hasAttribute(placeholderAttr) ||
-      !!dom.find(el, '[' + editableAttr + ']') ||
-      !!dom.find(el, '[' + placeholderAttr + ']');
-  }
-
-  /**
    * @constructs
    * @param {Element} el
    * @returns {Promise}
@@ -61,36 +49,34 @@ function ComponentEdit() {
       scope = this,
       walker, node, path;
 
-    if (isComponentEditable(el)) {
-      return edit.getComponentRef(ref).then(function (componentRef) {
-        walker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT, {
-          acceptNode: function (currentNode) {
-            if (!currentNode.hasAttribute(references.referenceAttribute)) {
-              return NodeFilter.FILTER_ACCEPT;
-            } else {
-              return NodeFilter.FILTER_REJECT;
-            }
-          }
-        });
-
-        // add click events to children with [name], but NOT children inside child components
-        while (node = walker.nextNode()) {
-          decorateNodes(node, walker, componentRef, promises);
+    return edit.getComponentRef(ref).then(function (componentRef) {
+    walker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT, {
+        acceptNode: function (currentNode) {
+        if (!currentNode.hasAttribute(references.referenceAttribute)) {
+            return NodeFilter.FILTER_ACCEPT;
+        } else {
+            return NodeFilter.FILTER_REJECT;
         }
-
-        // special case when editable path is in the component's root element.
-        if (componentHasPath) {
-          path = getDecoratorPath(el);
-          promises.push(decorate(el, componentRef, path));
         }
+    });
 
-        events.add(el, {
-          'a click': 'killLinks'
-        }, scope);
-
-        return Promise.all(promises);
-      });
+    // add click events to children with [name], but NOT children inside child components
+    while (node = walker.nextNode()) {
+        decorateNodes(node, walker, componentRef, promises);
     }
+
+    // special case when editable path is in the component's root element.
+    if (componentHasPath) {
+        path = getDecoratorPath(el);
+        promises.push(decorate(el, componentRef, path));
+    }
+
+    events.add(el, {
+        'a click': 'killLinks'
+    }, scope);
+
+    return Promise.all(promises);
+    });
   }
 
   constructor.prototype = {

--- a/controllers/component-edit.js
+++ b/controllers/component-edit.js
@@ -4,8 +4,7 @@
  */
 
 function ComponentEdit() {
-  var dom = require('@nymag/dom'),
-    edit = require('../services/edit'),
+  var edit = require('../services/edit'),
     events = require('../services/events'),
     references = require('../services/references'),
     decorate = require('../services/components/decorators'),
@@ -50,32 +49,32 @@ function ComponentEdit() {
       walker, node, path;
 
     return edit.getComponentRef(ref).then(function (componentRef) {
-    walker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT, {
+      walker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT, {
         acceptNode: function (currentNode) {
-        if (!currentNode.hasAttribute(references.referenceAttribute)) {
+          if (!currentNode.hasAttribute(references.referenceAttribute)) {
             return NodeFilter.FILTER_ACCEPT;
-        } else {
+          } else {
             return NodeFilter.FILTER_REJECT;
+          }
         }
-        }
-    });
+      });
 
     // add click events to children with [name], but NOT children inside child components
-    while (node = walker.nextNode()) {
+      while (node = walker.nextNode()) {
         decorateNodes(node, walker, componentRef, promises);
-    }
+      }
 
     // special case when editable path is in the component's root element.
-    if (componentHasPath) {
+      if (componentHasPath) {
         path = getDecoratorPath(el);
         promises.push(decorate(el, componentRef, path));
-    }
+      }
 
-    events.add(el, {
+      events.add(el, {
         'a click': 'killLinks'
-    }, scope);
+      }, scope);
 
-    return Promise.all(promises);
+      return Promise.all(promises);
     });
   }
 


### PR DESCRIPTION
Components without a editable or placeholder field were not being treated as editable, which meant that kiln, among other things, did not capture and squash clicks on <a> tags within components.  Often, these components did have their <a> click squashed by nature of having a PARENT who was editable, and on page load clay kiln would squash their links too (since the add() function of our events module searches for all children matching the tag).  However, subsequently created child components would not have their link clicks squashed.

We should treat all components as editable, as they are! Even if there is not actually a thing for them to edit.