### PR TITLE
Styling tweaks

### DIFF
--- a/behaviors/checkbox.scss
+++ b/behaviors/checkbox.scss
@@ -1,7 +1,7 @@
 @import '../styleguide/typography';
 
 .input-checkbox {
-  margin: 5px 0 10px;
+  margin: 5px 0 10px 2px; // left-margin space to accommodate browser focus display
 }
 
 .checkbox-label {

--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -87,6 +87,7 @@
 
 .editor-inline .input-label {
   margin: 0;
+  text-align: left; // override component styling
 }
 
 // when inline forms are opened, the other children of the parent element are hidden


### PR DESCRIPTION
Center alignment of lede feature elements was interfering with Kiln's form inputs. This PR keeps everything to the left.

[Trello Card](https://trello.com/c/2T5jNRHO/5-l-feature-article-default-lede)