### PR TITLE
sanitize blockquotes and other html entities when pasting

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -134,7 +134,18 @@ function createEditor(field, buttons) {
         [/&lt;(.*?)&gt;/ig, '<$1>'], // catch any html trying to be sent in as escaped strings,
         // thus allowing cleanTags (above) or text-model to manage them
         [/<h[1-9]>/ig, '<h2>'],
-        [/<\/h[1-9]>/ig, '</h2>'] // force all headers to the same level
+        [/<\/h[1-9]>/ig, '</h2>'], // force all headers to the same level
+        [/<\/?blockquote(.*?)>/ig, ''], // unwrap blockquotes
+        // decode SPECIFIC html entities (not all of them, as that's a security hole)
+        ['&amp;', '&'],
+        ['&nbsp;', ' '],
+        ['&ldquo;', '“'],
+        ['&rdguo;', '”'],
+        ['&lsquo;', '‘'],
+        ['&rsquo;', '’'],
+        ['&hellip;', '…'],
+        ['&mdash;', '—'],
+        ['&ndash;', '–']
       ]
     },
     anchor: {


### PR DESCRIPTION
* strip `<blockquote>`s from pasted text, allowing users to post quotes inside quote components without them getting double quoted (and fixing an unrecoverable error when pasting them into paragraph components)
* parse ampersands, curly quotes, ellipses, and dashes pasted as html entities
* parse nonbreaking spaces into regular spaces when pasted as html entities