### PR TITLE
fix sass imports from npm modules

### DIFF
--- a/behaviors/codemirror.scss
+++ b/behaviors/codemirror.scss
@@ -1,5 +1,5 @@
 @import '../styleguide/inputs';
-@import '../node_modules/codemirror/lib/codemirror';
+@import 'codemirror/lib/codemirror.css';
 
 .CodeMirror {
   @include input();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,6 @@ var gulp = require('gulp'),
   // uglify = require('gulp-uglify'),
   concat = require('gulp-concat'),
   sass = require('gulp-sass'),
-  rfn = require('responsive-filenames'),
   autoprefix = require('gulp-autoprefixer'),
   cssmin = require('gulp-cssmin'),
   prefixOptions = { browsers: ['last 2 versions', 'ie >= 9', 'ios >= 7', 'android >= 4.4.2'] },
@@ -29,7 +28,6 @@ var gulp = require('gulp'),
 gulp.task('styles', function () {
   return gulp.src(stylesGlob)
     .pipe(sass().on('error', sass.logError))
-    .pipe(rfn())
     .pipe(concat('clay-kiln.css'))
     .pipe(autoprefix(prefixOptions))
     .pipe(cssmin())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var gulp = require('gulp'),
   // uglify = require('gulp-uglify'),
   concat = require('gulp-concat'),
   sass = require('gulp-sass'),
+  sassImport = require('sass-import-modules').importer,
   autoprefix = require('gulp-autoprefixer'),
   cssmin = require('gulp-cssmin'),
   prefixOptions = { browsers: ['last 2 versions', 'ie >= 9', 'ios >= 7', 'android >= 4.4.2'] },
@@ -27,7 +28,7 @@ var gulp = require('gulp'),
 
 gulp.task('styles', function () {
   return gulp.src(stylesGlob)
-    .pipe(sass().on('error', sass.logError))
+    .pipe(sass({ importer: sassImport({ resolvers: ['local', 'partial', 'node']}) }).on('error', sass.logError))
     .pipe(concat('clay-kiln.css'))
     .pipe(autoprefix(prefixOptions))
     .pipe(cssmin())

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-duration": "^0.0.0",
     "gulp-if": "^2.0.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "nprogress": "^0.2.0",
     "rivets": "^0.8.1",
     "rollupify": "^0.2.0",
+    "sass-import-modules": "^2.1.0",
     "selection-range": "^1.0.1",
     "striptags": "^2.0.2",
     "text-model": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "medium-editor": "^5.21.0",
     "moment": "^2.10.6",
     "nprogress": "^0.2.0",
-    "responsive-filenames": "^1.2.0",
     "rivets": "^0.8.1",
     "rollupify": "^0.2.0",
     "selection-range": "^1.0.1",


### PR DESCRIPTION
As of npm v3, dependencies get flattened automatically so we can't rely on absolute paths for our codemirror (and potentially other) sass imports. This fixes the issue. Also removes responsive-filenames from our gulp script, since it's unused in kiln.