### PR TITLE
moved field interpolation to new service

### DIFF
--- a/decorators/README.md
+++ b/decorators/README.md
@@ -14,6 +14,7 @@ Each decorator should export a `when` method. It looks like this:
  * @param {string} options.ref component reference
  * @param {string} options.path path to the field or group
  * @param {object} options.data field or group data
+ * @param {object} options.componentData full data for the component
  * @returns {boolean}
  */
 function when(el, options) {
@@ -33,6 +34,7 @@ Each decorator should export a `handler` method that applies stuff to the elemen
  * @param {string} options.ref component reference
  * @param {string} options.path path to the field or group
  * @param {object} options.data field or group data
+ * @param {object} options.componentData full data for the component
  * @returns {Element} el
  */
 function handler(el, options) {

--- a/decorators/placeholder.js
+++ b/decorators/placeholder.js
@@ -23,14 +23,15 @@ function getFieldFromGroup(fieldName, groupFields) {
  * @param {string} path
  * @param {object} data
  * @param {object} data._schema
+ * @param {object} componentData
  * @returns {string}
  */
-function getPlaceholderText(path, data) {
+function getPlaceholderText(path, data, componentData) {
   var schema = data._schema,
     placeholder = schema[references.placeholderProperty];
 
   if (_.isObject(placeholder) && placeholder.text) {
-    return interpolate(placeholder.text, data);
+    return interpolate(placeholder.text, componentData);
   } else {
     return label(path, schema);
   }
@@ -316,7 +317,7 @@ function hasPlaceholder(el, options) {
 
 /**
  * @param {Element} el
- * @param {{ref: string, path: string, data: object}} options
+ * @param {{ref: string, path: string, data: object, componentData: object}} options
  * @returns {Element}
  */
 function addPlaceholder(el, options) {
@@ -324,7 +325,7 @@ function addPlaceholder(el, options) {
     schema = _.get(options, 'data._schema');
 
   return addPlaceholderDom(el, {
-    text: getPlaceholderText(path, options.data),
+    text: getPlaceholderText(path, options.data, options.componentData),
     height: getPlaceholderHeight(el, schema),
     permanent: getPlaceholderPermanence(schema),
     list: getPlaceholderList(el, options)

--- a/decorators/placeholder.test.js
+++ b/decorators/placeholder.test.js
@@ -44,53 +44,61 @@ describe(dirname, function () {
 
       it('uses property value in placeholder text if value exists', function () {
         var mockData = {
-          _schema: {
-            _placeholder: {
-              text: 'Value is ${mockProp}'
+            _schema: {
+              _placeholder: {
+                text: 'Value is ${mockProp}'
+              },
+              _name: 'mockProp'
             },
-            _name: 'mockProp'
+            value: 'some value'
           },
-          value: 'some value'
-        };
+          componentData = { mockProp: { value: 'some value' }};
 
-        expect(fn('mockProp', mockData)).to.equal('Value is some value');
+        expect(fn('mockProp', mockData, componentData)).to.equal('Value is some value');
       });
 
       it('uses values from a group in placeholder text if values exist', function () {
         var mockGroupData = {
-          value: [{
+            value: [{
+              _schema: {
+                _name: 'propA'
+              }, value: 'some value'
+            }, {
+              _schema: {
+                _name: 'propB'
+              }, value: 'another value'
+            }],
             _schema: {
-              _name: 'propA'
-            }, value: 'some value'
-          }, {
-            _schema: {
-              _name: 'propB'
-            }, value: 'another value'
-          }],
-          _schema: {
-            _name: 'mockGroup',
-            fields: ['propA', 'propB'],
-            _placeholder: {
-              text: 'A is ${propA} and B is ${propB}'
+              _name: 'mockGroup',
+              fields: ['propA', 'propB'],
+              _placeholder: {
+                text: 'A is ${propA} and B is ${propB}'
+              }
             }
-          }
-        };
+          },
+          componentData = {
+            propA: { value: 'some value' },
+            propB: { value: 'another value' }
+          };
 
-        expect(fn('mockGroup', mockGroupData)).to.equal('A is some value and B is another value');
+        expect(fn('mockGroup', mockGroupData, componentData)).to.equal('A is some value and B is another value');
       });
 
       it('uses empty string in placeholder text if value does not exist', function () {
         var mockData = {
-          _schema:{
-            _placeholder: {
-              text: 'Value is ${mockProp}'
+            _schema:{
+              _placeholder: {
+                text: 'Value is ${mockProp}'
+              },
+              _name: 'mockProp'
             },
-            _name: 'mockProp'
+            value: undefined
           },
-          value: undefined
-        };
+          componentData = {
+            mockProp: { value: null }
+          };
 
-        expect(fn('mockProp', mockData)).to.equal('Value is ');
+        expect(fn('mockProp', mockData, componentData)).to.equal('Value is ');
       });
     });
 

--- a/services/components/decorators.js
+++ b/services/components/decorators.js
@@ -27,6 +27,8 @@ function decorate(el, ref, path) {
 
     // add the data for this specific field or group
     options.data = groups.get(ref, data, path);
+    // add full component data, just in case decorators need to reference other fields
+    options.componentData = data;
     // iterate through all the decorators, calling the ones that need to run
     return _.map(window.kiln.decorators, function (decorator) {
       if (decorator.when(el, options)) {

--- a/services/interpolate-fields.js
+++ b/services/interpolate-fields.js
@@ -1,0 +1,29 @@
+const pattern = /\${\s*(\w+)\s*}/ig; // allows field value in text, e.g. 'The value is ${fieldName}'
+
+/**
+ * get a field's value
+ * @param {string} fieldName
+ * @param {object} data
+ * @returns {String}
+ */
+function getFieldVal(fieldName, data) {
+  var value = 'value';
+
+  console.log('\n\n' + fieldName)
+  console.log(data)
+  // always return a string; we cannot rely on the `toString` method as it can throw errors
+  return new String(_.get(data, value) || ''); // default to empty string
+}
+
+/**
+ * replace matched field name with field value
+ * @param {object} data
+ * @returns {Function}
+ */
+function replaceFieldName(data) {
+  return (match, fieldName) => getFieldVal(fieldName, data);
+}
+
+module.exports = function (str, data) {
+  return str.replace(pattern, replaceFieldName(data));
+};

--- a/services/interpolate-fields.test.js
+++ b/services/interpolate-fields.test.js
@@ -1,43 +1,38 @@
 var lib = require('./interpolate-fields');
 
 describe('field interpolation service', function () {
-  it('interpolates property value if value exists', function () {
-    var mockData = {
-      mockProp: {
-        value: 'some value'
-      }
-    };
-
-    expect(lib('Value is ${mockProp}', mockData)).to.equal('Value is some value');
+  it('interpolates string value', function () {
+    expect(lib('${prop}', { prop: { value: 'foo' }})).to.equal('foo');
   });
 
-  it('interpolates empty string if value is emptystring', function () {
-    var mockData = {
-      mockProp: {
-        value: ''
-      }
-    };
-
-    expect(fn('Value is ${mockProp}', mockData)).to.equal('Value is ');
+  it('interpolates number value', function () {
+    expect(lib('${prop}', { prop: { value: 123 }})).to.equal('123');
+    expect(lib('${prop}', { prop: { value: 0 }})).to.equal('0');
   });
 
-  it('interpolates empty string if value is null', function () {
-    var mockData = {
-      mockProp: {
-        value: null
-      }
-    };
-
-    expect(fn('Value is ${mockProp}', mockData)).to.equal('Value is ');
+  it('interpolates boolean value', function () {
+    expect(lib('${prop}', { prop: { value: true }})).to.equal('true');
+    expect(lib('${prop}', { prop: { value: false }})).to.equal('false');
   });
 
-  it('interpolates empty string if value is undefined', function () {
-    var mockData = {
-      mockProp: {
-        value: undefined
-      }
-    };
+  it('interpolates array', function () {
+    expect(lib('${prop}', { prop: ['foo', 'bar', 'baz'] })).to.equal('foo, bar, baz');
+  });
 
-    expect(fn('Value is ${mockProp}', mockData)).to.equal('Value is ');
+  it('interpolates falsy values', function () {
+    expect(lib('${prop}', { prop: { value: null }})).to.equal('');
+    expect(lib('${prop}', { prop: { value: undefined }})).to.equal('');
+    expect(lib('${prop}', { prop: [] })).to.equal('');
+    expect(lib('${prop}', { prop: null })).to.equal('');
+    expect(lib('${prop}', { prop: {} })).to.equal(''); // no value
+    expect(lib('${prop}', { prop: undefined })).to.equal('');
+  });
+
+  it('does NOT interpolate array of objects', function () {
+    expect(lib('${prop}', { prop: [{}, {}, {}] })).to.equal('');
+  });
+
+  it('does NOT interpolate object', function () {
+    expect(lib('${prop}', { prop: {} })).to.equal('');
   });
 });

--- a/services/interpolate-fields.test.js
+++ b/services/interpolate-fields.test.js
@@ -1,0 +1,43 @@
+var lib = require('./interpolate-fields');
+
+describe('field interpolation service', function () {
+  it('interpolates property value if value exists', function () {
+    var mockData = {
+      mockProp: {
+        value: 'some value'
+      }
+    };
+
+    expect(lib('Value is ${mockProp}', mockData)).to.equal('Value is some value');
+  });
+
+  it('interpolates empty string if value is emptystring', function () {
+    var mockData = {
+      mockProp: {
+        value: ''
+      }
+    };
+
+    expect(fn('Value is ${mockProp}', mockData)).to.equal('Value is ');
+  });
+
+  it('interpolates empty string if value is null', function () {
+    var mockData = {
+      mockProp: {
+        value: null
+      }
+    };
+
+    expect(fn('Value is ${mockProp}', mockData)).to.equal('Value is ');
+  });
+
+  it('interpolates empty string if value is undefined', function () {
+    var mockData = {
+      mockProp: {
+        value: undefined
+      }
+    };
+
+    expect(fn('Value is ${mockProp}', mockData)).to.equal('Value is ');
+  });
+});


### PR DESCRIPTION
* added `componentData` to options passed into decorators
* moved placeholder's field name interpolation to new service
* added tests

Now it'll be super easy to interpolate component data in any situation where we might want it, e.g. if we want _per-instance_ component names in selectors or other lists #525