### PR TITLE
Add missing require('lodash') from interpolate fields service

### DIFF
--- a/services/interpolate-fields.js
+++ b/services/interpolate-fields.js
@@ -1,4 +1,5 @@
-const pattern = /\${\s*(\w+)\s*}/ig; // allows field value in text, e.g. 'The value is ${fieldName}'
+const _ = require('lodash'),
+  pattern = /\${\s*(\w+)\s*}/ig; // allows field value in text, e.g. 'The value is ${fieldName}'
 
 /**
  * get a field's value


### PR DESCRIPTION
Follow-up to https://github.com/nymag/clay-kiln/commit/c1e19a96d85531abbad9947cec5ea11f581ec985 and https://github.com/nymag/clay-kiln/pull/533