### PR TITLE
set maxwidth for inline forms

### DIFF
--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -69,6 +69,11 @@
   padding: 30px 20px 50px;
 }
 
+.editor-inline {
+  max-width: 90vw;
+  margin: 0 auto;
+}
+
 .editor-inline .input-container {
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
this prevents BIG inline forms from smooshing against the edges of the viewport, since inline forms don't have any inherent padding.

before:

![screen shot 2016-07-27 at 3 10 59 pm](https://cloud.githubusercontent.com/assets/447522/17188716/618ff062-540c-11e6-8a12-13eef17054be.png)

after:

![screen shot 2016-07-27 at 3 10 45 pm](https://cloud.githubusercontent.com/assets/447522/17188724/69cbf96a-540c-11e6-9a5e-75218b446ec7.png)
