### PR TITLE
re-styled publish pane

### DIFF
--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -46,7 +46,6 @@ function unschedulePageAndLayout() {
 
 module.exports = function () {
   function constructor(el) {
-    this.el = el;
     this.form = dom.find(el, '.schedule');
   }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dollar-slice": "^2.1.0",
     "domify": "^1.3.3",
     "dragula": "^3.5.4",
-    "flatpickr": "^1.8.9",
+    "flatpickr": "^1.9.1",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.0.1",
     "gulp-concat": "^2.6.0",

--- a/services/pane.js
+++ b/services/pane.js
@@ -196,8 +196,8 @@ function createPublishActions(res) {
     }
 
     // init datepicker for non-native browsers
-    datepicker.init(scheduleDate);
-    datepicker.init(scheduleTime);
+    datepicker.init(scheduleDate, {static: true});
+    datepicker.init(scheduleTime, {static: true});
   }
 
   return actions;

--- a/services/pane.js
+++ b/services/pane.js
@@ -71,6 +71,36 @@ function open(header, innerEl, modifier) {
 }
 
 /**
+ * create actions for undoing scheduling and publishing
+ * @param {object} res
+ * @returns {Element}
+ */
+function createUndoActions(res) {
+  const undo = tpl.get('.publish-undo-template');
+
+  let unpublish, unschedule;
+
+  // unscheduling
+  if (res.scheduled) {
+    state.toggleScheduled(true); // just in case someone else scheduled this page
+    unschedule = dom.find(undo, '.unschedule');
+    if (unschedule) {
+      unschedule.classList.remove(kilnHideClass);
+    }
+  }
+
+  // unpublish (only affects page)
+  if (res.published) {
+    unpublish = dom.find(undo, '.unpublish');
+    if (unpublish) {
+      unpublish.classList.remove(kilnHideClass);
+    }
+  }
+
+  return undo;
+}
+
+/**
  * create validation messages
  * @param {array} [warnings]
  * @returns {Element}
@@ -142,7 +172,7 @@ function createPublishActions(res) {
   const actions = tpl.get('.publish-actions-template'),
     val = getScheduledValues(res);
 
-  let scheduleDate, scheduleTime, unpublish, unschedule;
+  let scheduleDate, scheduleTime;
 
   // set date and time
   if (actions) {
@@ -165,23 +195,6 @@ function createPublishActions(res) {
     datepicker.init(scheduleTime);
   }
 
-  // unscheduling
-  if (res.scheduled) {
-    state.toggleScheduled(true); // just in case someone else scheduled this page
-    unschedule = dom.find(actions, '.unschedule');
-    if (unschedule) {
-      unschedule.classList.remove(kilnHideClass);
-    }
-  }
-
-  // unpublish (only affects page)
-  if (res.published) {
-    unpublish = dom.find(actions, '.unpublish');
-    if (unpublish) {
-      unpublish.classList.remove(kilnHideClass);
-    }
-  }
-
   return actions;
 }
 
@@ -197,6 +210,7 @@ function openPublish(warnings) {
 
   return state.get().then(function (res) {
     // append validation, message, and actions to the doc fragment
+    innerEl.appendChild(createUndoActions(res));
     innerEl.appendChild(createPublishValidation(warnings));
     innerEl.appendChild(createPublishMessages(res));
     innerEl.appendChild(createPublishActions(res));
@@ -205,7 +219,7 @@ function openPublish(warnings) {
     el = open(header, innerEl);
     // init controller for publish pane
     ds.controller('publish-pane', publishPaneController);
-    ds.get('publish-pane', el.querySelector('.actions'));
+    ds.get('publish-pane', el);
   });
 }
 

--- a/services/pane.js
+++ b/services/pane.js
@@ -80,6 +80,11 @@ function createUndoActions(res) {
 
   let unpublish, unschedule;
 
+  // show undo actions if either are available
+  if (res.scheduled || res.published) {
+    dom.find(undo, '.undo').classList.remove(kilnHideClass);
+  }
+
   // unscheduling
   if (res.scheduled) {
     state.toggleScheduled(true); // just in case someone else scheduled this page

--- a/services/pane.test.js
+++ b/services/pane.test.js
@@ -17,6 +17,13 @@ function stubWrapperTemplate() {
   </div>`);
 }
 
+function stubUndoTemplate() {
+  return dom.create(`<div class="publish-undo undo kiln-hide">
+    <button class="unpublish kiln-hide">Unpublish Page</button>
+    <button class="unschedule kiln-hide">Unschedule</button>
+  </div>`);
+}
+
 function stubMessageTemplate() {
   return dom.create(`<div class="publish-messages messages">
     <p class="publish-state-message">In Draft.</p>
@@ -26,6 +33,7 @@ function stubMessageTemplate() {
 
 function stubPublishTemplate() {
   return dom.create(`<div class="publish-actions actions">
+    <button class="publish-now">Publish Now</button>
     <form class="schedule">
       <label class="schedule-label" for="schedule-date">Date</label>
       <input id="schedule-date" class="schedule-input" type="date" min="" value="" placeholder=""></input>
@@ -33,9 +41,6 @@ function stubPublishTemplate() {
       <input id="schedule-time" class="schedule-input" type="time" value="" placeholder=""></input>
       <button class="schedule-publish">Schedule Publish</button>
     </form>
-    <button class="unschedule kiln-hide">Unschedule</button>
-    <button class="publish-now">Publish Now</button>
-    <button class="unpublish kiln-hide">Unpublish Page</button>
   </div>`);
 }
 
@@ -68,6 +73,7 @@ describe(dirname, function () {
       getTemplate = sandbox.stub(tpl, 'get');
       getTemplate.withArgs('.kiln-pane-template').returns(stubWrapperTemplate());
       getTemplate.withArgs('.publish-valid-template').returns(dom.create('<div class="publish-valid">valid</div>'));
+      getTemplate.withArgs('.publish-undo-template').returns(stubUndoTemplate());
       getTemplate.withArgs('.publish-messages-template').returns(stubMessageTemplate());
       getTemplate.withArgs('.publish-actions-template').returns(stubPublishTemplate());
       getTemplate.withArgs('.new-page-actions-template').returns(dom.create('<div><div class="new-page-actions actions"></div></div>')); // wrapper divs to simulate doc fragments

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -99,55 +99,157 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
   padding: 20px 20px 40px;
 }
 
-.kiln-toolbar-pane .info-message {
-  @include primary-text();
+@mixin pane-border-before {
+  position: relative;
+  width: 100%;
 
-  color: $black-50;
-  padding: 0 0 20px;
+  &:before {
+    border-top: 1px solid $grey;
+    content: '';
+    left: -20px;
+    position: absolute;
+    top: 0;
+    width: calc(100% + 40px);
+  }
+}
+
+@mixin pane-border-after {
+  position: relative;
+  width: 100%;
+
+  &:after {
+    border-bottom: 1px solid $grey;
+    bottom: 0;
+    content: '';
+    left: -20px;
+    position: absolute;
+    width: calc(100% + 40px);
+  }
+}
+
+@mixin full-width {
+  float: none; // overrides button float
+  margin: 0;
+  position: relative;
+  width: 100%;
 }
 
 /* types of panes */
 
 /* publish */
 
+// undo actions
+.kiln-toolbar-pane .undo {
+  @include pane-border-after();
+}
+
+.kiln-toolbar-pane .unpublish {
+  @include button-outlined($black-50, $white);
+  @include full-width();
+
+  margin-bottom: 20px;
+  // will space buttons when both are visible, otherwise will space bottom border
+}
+
+.kiln-toolbar-pane .unschedule {
+  @include button-outlined($black-50, $white);
+  @include full-width();
+
+  margin-bottom: 20px;
+  // will space buttons when both are visible, otherwise will space bottom border
+}
+
+// validation messages
+.kiln-toolbar-pane .publish-valid {
+  align-items: center;
+  display: flex;
+  padding: 20px 0;
+}
+
+.kiln-toolbar-pane .kiln-hide + .publish-valid {
+  padding: 0 0 20px; // if undo is hidden, we don't need top padding
+}
+
+.kiln-toolbar-pane .undo:not(.kiln-hide) + .warning-message {
+  padding: 20px 0 20px; // if undo is shown, we need extra padding
+  // note: we can't just check for .kiln-hide because warnings also appear
+  // in the errors pane
+}
+
+.kiln-toolbar-pane .publish-valid-icon {
+  margin-right: 16px;
+}
+
+.publish-valid-icon svg {
+  display: inline-block;
+  fill: $green;
+  height: 24px;
+  width: 24px;
+}
+
+.publish-valid-message {
+  color: $green;
+  margin: 4px 0; // vertically center with the icon (24px - 16px)
+}
+
+// info / status messages
 .kiln-toolbar-pane .messages {
-  padding-top: 20px;
-  position: relative;
+  @include pane-border-before(); // will display after validation or warnings
+  @include full-width();
+
+  padding: 20px 0;
 
   p {
     color: $black-50;
-    margin: 0 0 10px;
+    margin: 0;
+    padding: 0;
   }
 }
 
-.kiln-toolbar-pane .publish-messages:before {
-  border-top: 1px solid $grey;
-  content: '';
-  left: -20px;
-  position: absolute;
-  top: 0;
-  width: calc(100% + 40px);
+// publish now
+.kiln-toolbar-pane .actions {
+  @include full-width();
 }
 
-.kiln-toolbar-pane .actions,
+.kiln-toolbar-pane .publish-now {
+  @include button-outlined($green, $white);
+  @include full-width();
+}
+
+// schedule form
+.kiln-toolbar-pane .schedule-border {
+  // needs a separate element because firefox has issues with absolutely-positioned
+  // child elements of flexbox containers that use justify-content: space-between
+  @include pane-border-before();
+  @include full-width();
+
+  margin: 20px 0 0;
+  padding: 20px 0 0;
+}
 .kiln-toolbar-pane .schedule {
-  @include clearfix();
+  @include full-width();
 
-  width: 100%;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
 }
 
-.kiln-toolbar-pane .preview-actions {
-  width: 100%;
+$half-minus-20: calc(50% - 10px);
+
+.kiln-toolbar-pane .schedule-item {
+  flex: 0 0 $half-minus-20;
+  width: $half-minus-20;
 }
 
 .kiln-toolbar-pane .schedule-label {
   @include label();
 
-  margin: 15px 0 5px;
+  margin: 0 0 5px;
 }
 
 .kiln-toolbar-pane .schedule-input,
-.kiln-toolbar-pane .preview-input,
 .kiln-toolbar-pane .kiln-input { // generic input class, used by flatpickr
   @include input();
 
@@ -162,56 +264,9 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
 
 .kiln-toolbar-pane .schedule-publish {
   @include button-outlined($orange, $white);
-}
+  @include full-width();
 
-.kiln-toolbar-pane .unschedule {
-  @include button-outlined($black-50, $white);
-}
-
-.kiln-toolbar-pane .primary-action,
-.kiln-toolbar-pane .publish-now {
-  @include button-outlined($green, $white);
-}
-
-.kiln-toolbar-pane .unpublish {
-  @include button-outlined($black-50, $white);
-}
-
-.kiln-toolbar-pane .primary-action,
-.kiln-toolbar-pane .schedule-publish,
-.kiln-toolbar-pane .publish-now {
-  margin: 15px 0 0;
-  width: 100%;
-}
-
-.kiln-toolbar-pane .unschedule {
-  margin: 15px 0 12px;
-  position: relative;
-  width: 100%;
-
-  &:after {
-    border-bottom: 1px solid $grey;
-    bottom: -15px;
-    content: '';
-    left: -20px;
-    position: absolute;
-    width: calc(100% + 40px);
-  }
-}
-
-.kiln-toolbar-pane .unpublish {
-  margin: 27px 0 0;
-  position: relative;
-  width: 100%;
-
-  &:before {
-    border-bottom: 1px solid $grey;
-    content: '';
-    left: -20px;
-    position: absolute;
-    top: -15px;
-    width: calc(100% + 40px);
-  }
+  margin-top: 20px;
 }
 
 /* validation errors */
@@ -224,9 +279,9 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
 }
 
 .kiln-toolbar-pane .publish-error {
+  @include pane-border-before();
   @include primary-text();
 
-  border-top: 1px solid $grey;
   padding: 20px 0;
 
   .label {
@@ -263,6 +318,8 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
   margin-left: 5px;
 }
 
+/* easter egg pane */
+
 .kiln-toolbar-pane .cats-ayb {
   height: 200px;
   width: 335px;
@@ -284,33 +341,39 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
   padding-top: 20px;
 }
 
-/* validation ok */
+/* preview pane */
 
-.kiln-toolbar-pane .publish-valid {
-  align-items: center;
-  display: flex;
-  margin-bottom: 20px;
-  position: relative;
+.kiln-toolbar-pane .info-message {
+  @include primary-text();
+
+  color: $black-50;
+  padding: 0 0 20px;
+}
+
+.kiln-toolbar-pane .preview-actions {
   width: 100%;
 }
 
-.kiln-toolbar-pane .publish-valid-icon {
-  margin-right: 16px;
+.kiln-toolbar-pane .preview-input {
+  @include input();
+
+  cursor: initial;
+  margin: 0;
+  padding: 8px 10px 7px;
 }
 
-.publish-valid-icon svg {
-  display: inline-block;
-  fill: $green;
-  height: 24px;
-  width: 24px;
-}
+/* new page pane */
 
-.publish-valid-message {
-  color: $green;
-  margin: 4px 0; // vertically center with the icon (24px - 16px)
+// note: this will use the filtered item styles in the future
+.kiln-toolbar-pane .primary-action {
+  @include button-outlined($green, $white);
+
+  margin: 15px 0 0;
+  width: 100%;
 }
 
 /* filtered item search pane (add component, possibly new page in the future) */
+
 .kiln-toolbar-pane .filtered-input {
   @include input();
 

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -236,11 +236,13 @@ $easeOutExpo: cubic-bezier(.190, 1.000, .220, 1.000);
   padding: 0;
 }
 
-$half-minus-20: calc(50% - 10px);
+$schedule-item-width: calc(50% - 8px);
+// close enough to 10px (standard margins in this form),
+// but enough space for chrome to display its datepicker toggles
 
 .kiln-toolbar-pane .schedule-item {
-  flex: 0 0 $half-minus-20;
-  width: $half-minus-20;
+  flex: 0 0 $schedule-item-width;
+  width: $schedule-item-width;
 }
 
 .kiln-toolbar-pane .schedule-label {

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -66,7 +66,7 @@
     {# sub-templates: undoing scheduling and publishing #}
     {# publish undo #}
     <template class="publish-undo-template">
-      <div class="publish-undo">
+      <div class="publish-undo undo kiln-hide">
         <button class="unpublish kiln-hide">Unpublish Page</button>
         <button class="unschedule kiln-hide">Unschedule</button>
       </div>
@@ -95,11 +95,16 @@
     <template class="publish-actions-template">
       <div class="publish-actions actions">
         <button class="publish-now">Publish Now</button>
+        <div class="schedule-border"></div>
         <form class="schedule">
-          <label class="schedule-label" for="schedule-date">Date</label>
-          <input id="schedule-date" class="schedule-input" type="date" min="" value="" placeholder=""></input>
-          <label class="schedule-label" for="schedule-time">Time</label>
-          <input id="schedule-time" class="schedule-input" type="time" value="" placeholder=""></input>
+          <div class="schedule-item">
+            <label class="schedule-label" for="schedule-date">Date</label>
+            <input id="schedule-date" class="schedule-input" type="date" min="" value="" placeholder=""></input>
+          </div>
+          <div class="schedule-item">
+            <label class="schedule-label" for="schedule-time">Time</label>
+            <input id="schedule-time" class="schedule-input" type="time" value="" placeholder=""></input>
+          </div>
           <button class="schedule-publish">Schedule Publish</button>
         </form>
 

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -63,6 +63,15 @@
       </div>
     </template>
 
+    {# sub-templates: undoing scheduling and publishing #}
+    {# publish undo #}
+    <template class="publish-undo-template">
+      <div class="publish-undo">
+        <button class="unpublish kiln-hide">Unpublish Page</button>
+        <button class="unschedule kiln-hide">Unschedule</button>
+      </div>
+    </template>
+
     {# sub-template: publishing validation #}
     {# valid message #}
     <template class="publish-valid-template">
@@ -78,7 +87,6 @@
       <div class="publish-messages messages">
         <p class="publish-state-message">In Draft.</p>
         <p class="publish-schedule-message kiln-hide">Scheduled to publish</p>
-        <p class="publish-effect-message">Changes you make outside of the article will also be published.</p>
       </div>
     </template>
 
@@ -86,6 +94,7 @@
     {# publish actions #}
     <template class="publish-actions-template">
       <div class="publish-actions actions">
+        <button class="publish-now">Publish Now</button>
         <form class="schedule">
           <label class="schedule-label" for="schedule-date">Date</label>
           <input id="schedule-date" class="schedule-input" type="date" min="" value="" placeholder=""></input>
@@ -93,9 +102,7 @@
           <input id="schedule-time" class="schedule-input" type="time" value="" placeholder=""></input>
           <button class="schedule-publish">Schedule Publish</button>
         </form>
-        <button class="unschedule kiln-hide">Unschedule</button>
-        <button class="publish-now">Publish Now</button>
-        <button class="unpublish kiln-hide">Unpublish Page</button>
+
       </div>
     </template>
 


### PR DESCRIPTION
* unpublish and unschedule at the top
* made margins and padding consistent across all states
* removed intermingled styles for different panes in favor of using mixins
* updated flatpickr

![screen shot 2016-08-03 at 11 02 04 am](https://cloud.githubusercontent.com/assets/447522/17371337/7abc54ca-596d-11e6-9ccc-d6b5dbfeeac9.png)

After publishing, unpublish is at the top:

![screen shot 2016-08-03 at 11 10 06 am](https://cloud.githubusercontent.com/assets/447522/17371350/89851424-596d-11e6-858a-fb7da391544b.png)

Validation warnings have consistent styles now:

![screen shot 2016-08-03 at 11 05 48 am](https://cloud.githubusercontent.com/assets/447522/17371372/9763cb76-596d-11e6-8127-3fc69e2d17c2.png)

If there are warnings, and a page is published, and it's scheduled, everything remains consistent:

![screen shot 2016-08-03 at 11 09 24 am](https://cloud.githubusercontent.com/assets/447522/17371389/ac6147c4-596d-11e6-8d65-b213b4b61580.png)
