### PR TITLE
Add phrase button to wysiwyg.

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -2,6 +2,8 @@ var _ = require('lodash'),
   select = require('selection-range'),
   MediumEditor = require('medium-editor'),
   MediumButton = require('@yoshokatana/medium-button'),
+  MediumEditorPhrase = require('medium-editor-phrase'),
+  safeAttribute = require('../services/field-helpers/safe-attribute'),
   dom = require('@nymag/dom'),
   db = require('../services/edit/db'),
   render = require('../services/components/render'),
@@ -104,10 +106,30 @@ function toggleTieredToolbar(html) {
 /**
  * create new medium editor
  * @param {Element} field
- * @param {array} buttons
+ * @param {[string|object]} buttonsWithOptions  array containing strings and objects
  * @returns {Element}
  */
-function createEditor(field, buttons) {
+function createEditor(field, buttonsWithOptions) {
+  var extensions = {
+      tieredToolbar: new MediumButton({
+        label: '&hellip;',
+        action: toggleTieredToolbar
+      })
+    },
+    buttons = buttonsWithOptions.map(button => {
+      let type, settings;
+
+      if (_.isObject(button)) { // button is an object with settings
+        type = Object.keys(button)[0];
+        settings = button[type];
+        if (type === 'phrase') {
+          extensions[settings.name] = new MediumEditorPhrase(settings); // add button to extensions
+        }
+        return settings.name;
+      }
+      return button; // button is a string
+    });
+
   // add "remove formatting" button to the end
   buttons.push('removeFormat');
 
@@ -156,12 +178,7 @@ function createEditor(field, buttons) {
     targetBlank: true,
     disableReturn: true,
     placeholder: false, // the placeholder isn't native
-    extensions: {
-      tieredToolbar: new MediumButton({
-        label: '&hellip;',
-        action: toggleTieredToolbar
-      })
-    }
+    extensions: extensions
   });
 }
 
@@ -496,7 +513,7 @@ function initWysiwygBinder(enableKeyboardExtras) {
     publish: true,
     bind: function (el) {
       // this is called when the binder initializes
-      var toolbarButtons = el.getAttribute('data-wysiwyg-buttons').split(','),
+      var toolbarButtons = safeAttribute.readAttrObject(el, 'data-wysiwyg-buttons'),
         observer = this.observer,
         data = observer.value() || '', // don't print 'undefined' if there's no data
         editor = createEditor(el, toolbarButtons),
@@ -591,8 +608,8 @@ function initWysiwygBinder(enableKeyboardExtras) {
 /**
  * Create WYSIWYG text editor.
  * @param {{name: string, el: Element, binders: {}}} result
- * @param {{buttons: [string], styled: boolean, enableKeyboardExtras: boolean}} args  Described in detail below:
- * @param {[string]} args.buttons  array of button names (strings) for tooltip
+ * @param {{buttons: Array, styled: boolean, enableKeyboardExtras: boolean}} args  Described in detail below:
+ * @param {Array} args.buttons  array of button names (strings) for tooltip, buttons with options are objects rather than strings
  * @param {boolean}  args.styled   apply input styles to contenteditable element
  * @param {boolean}  args.enableKeyboardExtras  enable creating new components on enter, and appending text to previous components on delete, etc
  * @returns {{}}
@@ -604,7 +621,7 @@ module.exports = function (result, args) {
     styled = args.styled,
     enableKeyboardExtras = args.enableKeyboardExtras,
     field = dom.create(`<label class="input-label">
-      <p class="wysiwyg-input${ addStyledClass(styled) }" rv-field="${name}" rv-wysiwyg="${name}.data.value" data-wysiwyg-buttons="${buttons.join(',')}"></p>
+      <p class="wysiwyg-input${ addStyledClass(styled) }" rv-field="${name}" rv-wysiwyg="${name}.data.value" ${safeAttribute.writeObjectAsAttr('data-wysiwyg-buttons', buttons)}></p>
     </label>`);
 
   // if more than 5 buttons, put the rest on the second tier

--- a/behaviors/wysiwyg.md
+++ b/behaviors/wysiwyg.md
@@ -6,7 +6,7 @@ _Note:_ When this behavior is added to a field, it will replace any previous ele
 
 ## Arguments
 
-* **buttons** _(optional)_  array of button names (strings) for text styling. defaults to "remove formatting"
+* **buttons** _(optional)_  array of button names (strings) or custom buttons (objects) for text styling. defaults to "remove formatting"
 * **styled** _(optional)_   style the content editable element like our `text` and `textarea` inputs.
 * **enableKeyboardExtras** _(optional)_  enable creating new components on enter, and appending text to previous components on delete, etc
 
@@ -16,6 +16,7 @@ The buttons allowed in our wysiwyg behavior are:
 * italic
 * strikethrough
 * anchor
+* phrase - uses [Medium Editor Phrase](https://github.com/nymag/medium-editor-phrase) and takes [documented options](https://github.com/nymag/medium-editor-phrase#initialization-options). See the example below for a full example.
 
 By default, wysiwyg fields will use the styles of the containing component. To use our kiln input styling, set `styled` to `true`.
 
@@ -27,3 +28,22 @@ By default, wysiwyg fields will use the styles of the containing component. To u
 * hitting <kbd>shift+enter</kbd> will insert a soft break
 
 _Note:_ All pasted text gets run through [text-model](https://github.com/nymag/text-model). Pasting in multiple paragraphs will create multiple instances of the current component with the respective paragraphs of text added to each instance.
+
+## Example
+```
+text:
+  _has:
+    -
+      fn: wysiwyg
+      buttons:
+        - bold
+        - italic
+        - strikethrough
+        - anchor
+        - phrase:
+            aria: annotate
+            name: annotate
+            contentDefault: A¹
+            phraseClassList: ['clay-annotated']
+            phraseTagName: span
+```

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "lodash": "^3.8.0",
     "lodash-deep": "^1.6.0",
     "medium-editor": "^5.21.0",
+    "medium-editor-phrase": "nymag/medium-editor-phrase",
     "mocha": "^2.2.5",
     "moment": "^2.10.6",
     "nprogress": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lodash": "^3.8.0",
     "lodash-deep": "^1.6.0",
     "medium-editor": "^5.21.0",
-    "medium-editor-phrase": "nymag/medium-editor-phrase",
+    "medium-editor-phrase": "^1.0.0",
     "mocha": "^2.2.5",
     "moment": "^2.10.6",
     "nprogress": "^0.2.0",

--- a/services/field-helpers/safe-attribute.js
+++ b/services/field-helpers/safe-attribute.js
@@ -1,0 +1,40 @@
+/**
+ *
+ * @param {object} obj
+ * @returns {string}
+ */
+function objectToSafeString(obj) {
+  return JSON.stringify(obj).replace(/'/g, '\\\'');
+}
+
+/**
+ *
+ * @param {string} str
+ * @returns {object}
+ */
+function safeStringToObject(str) {
+  return JSON.parse(str.replace(/\\'/g, '\'') || 'null');
+}
+
+/**
+ * populate an element's attribute with an object safely converted to a string
+ * @param {string} attrName
+ * @param {object} obj
+ * @returns {string} e.g. `data-somthing='{"a":"it\'s ok"}'`
+ */
+function writeObjectAsAttr(attrName, obj) {
+  return attrName + '=\'' + objectToSafeString(obj) + '\''; // uses single quotes around attribute value
+}
+
+/**
+ * safely read an element's attribute value that was an object converted to a string
+ * @param {Element} el
+ * @param {string} attrName
+ * @returns {object}
+ */
+function readAttrObject(el, attrName) {
+  return safeStringToObject(el.getAttribute(attrName) || '');
+}
+
+module.exports.writeObjectAsAttr = writeObjectAsAttr;
+module.exports.readAttrObject = readAttrObject;

--- a/services/field-helpers/safe-attribute.test.js
+++ b/services/field-helpers/safe-attribute.test.js
@@ -1,0 +1,31 @@
+var dirname = __dirname.split('/').pop(),
+  filename = __filename.split('/').pop().split('.').shift(),
+  lib = require('./safe-attribute'); // static-analysis means this must be string, not ('./' + filename);
+
+describe(dirname, function () {
+  describe(filename, function () {
+    var el;
+
+    beforeEach(function () {
+      el = document.createElement('div');
+    });
+
+    describe('writeObjectAsAttr', function () {
+      var fn = lib[this.title];
+
+      it('converts object to html string with attribute and value', function () {
+        expect(fn('data-something', {a: 'value \'is\' good.'})).to.equal('data-something=\'{"a":"value \\\'is\\\' good."}\'');
+      });
+    });
+
+    describe('readAttrObject', function () {
+      var fn = lib[this.title];
+
+      it('gets string from data-attribute and converts to object', function () {
+        el.setAttribute('data-something', '{"a":"value \\\'is\\\' good."}');
+        expect(fn(el, 'data-something')).to.deep.equal({a: 'value \'is\' good.'});
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
For our purposes a "phrase" is a group of one or more words.

This PR allows any component to add a phrase button to the wysiwyg behavior.

e.g.
```
text:
  _has:
    -
      fn: wysiwyg
      buttons:
        - bold
        - italic
        - strikethrough
        - anchor
        - phrase:
            aria: annotate
            name: annotate
            contentDefault: A¹
            phraseClassList: ['clay-annotated'] # adds this class to the span
            phraseTagName: span
```

https://trello.com/c/EUYTk5fh/13-l-new-article-component-footnotes