### PR TITLE
config settings to generate html cover coverage reports locally

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,6 +22,8 @@ settings = {
         presets: ['es2015']
       }),
       istanbul({
+        // this config fixes the following:
+        // https://github.com/karma-runner/karma-coverage/issues/157
         instrumenterConfig: {
           embedSource: true
         },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,6 +22,9 @@ settings = {
         presets: ['es2015']
       }),
       istanbul({
+        instrumenterConfig: {
+          embedSource: true
+        },
         ignore: [
           '**/*.test.js',
           '**/*.md',

--- a/karma.local.conf.js
+++ b/karma.local.conf.js
@@ -1,12 +1,15 @@
 var settings = require('./karma.conf.js').settings,
   _ = require('lodash');
 
+// generating code coverage reports for local tests
+settings.coverageReporter.type = 'html';
+
 module.exports = function (karma) {
   karma.set(_.assign(settings, {
     singleRun: false,
     autoWatch: true,
     autoWatchBatchDelay: 1000,
-    reporters: ['spec'],
+    reporters: ['spec', 'coverage'],
     browsers: ['Chrome']
   }));
 };


### PR DESCRIPTION
some karma config changes so that HTML code coverage reports are generated when we run `npm run test-local`.

HTML reports would provide more immediate feedback than using coveralls.io