### PR TITLE
add settings and remove options to filterable lists

### DIFF
--- a/controllers/filterable-list.js
+++ b/controllers/filterable-list.js
@@ -91,7 +91,9 @@ module.exports = function () {
       '.filtered-input keyup': 'onInputKeyup',
       '.filtered-item keydown': 'onItemKeydown',
       '.filtered-item keyup': 'onItemKeyup',
-      '.filtered-item click': 'onItemClick'
+      '.filtered-item-title click': 'onItemClick',
+      // optional events
+      '.filtered-item-remove click': 'onRemoveClick'
     },
 
     onInputKeydown: function (e) {
@@ -134,14 +136,14 @@ module.exports = function () {
     onItemKeydown: function (e) {
       // simulate active states when pressing enter
       if (keyCode(e) === 'enter') {
-        e.target.classList.add('active');
+        e.currentTarget.classList.add('active');
       }
     },
 
     onItemKeyup: function (e) {
       var key = keyCode(e),
         available = getAvailable(this.items),
-        currentItem = e.target;
+        currentItem = e.currentTarget;
 
       // remove any active state if it exists
       currentItem.classList.remove('active');
@@ -170,8 +172,19 @@ module.exports = function () {
     },
 
     onItemClick: function (e) {
+      var id = e.currentTarget.parentElement.getAttribute('data-item-id');
+
       e.preventDefault();
-      this.options.click(e.target.getAttribute('data-item-id'));
+      this.options.click(id);
+    },
+
+    onRemoveClick: function (e) {
+      var id = e.currentTarget.parentElement.getAttribute('data-item-id'),
+        confirm = window.confirm('Remove from this list?'); // eslint-disable-line
+
+      if (confirm) {
+        this.options.remove(id);
+      }
     }
   };
   return constructor;

--- a/controllers/filterable-list.js
+++ b/controllers/filterable-list.js
@@ -93,7 +93,8 @@ module.exports = function () {
       '.filtered-item keyup': 'onItemKeyup',
       '.filtered-item-title click': 'onItemClick',
       // optional events
-      '.filtered-item-remove click': 'onRemoveClick'
+      '.filtered-item-remove click': 'onRemoveClick',
+      '.filtered-item-settings click': 'onSettingsClick'
     },
 
     onInputKeydown: function (e) {
@@ -185,6 +186,12 @@ module.exports = function () {
       if (confirm) {
         this.options.remove(id);
       }
+    },
+
+    onSettingsClick: function (e) {
+      var id = e.currentTarget.parentElement.getAttribute('data-item-id');
+
+      this.options.settings(id);
     }
   };
   return constructor;

--- a/services/filterable-list.js
+++ b/services/filterable-list.js
@@ -1,32 +1,43 @@
-var _ = require('lodash'),
+const _ = require('lodash'),
   dom = require('@nymag/dom'),
   ds = require('dollar-slice'),
   label = require('./label'),
   tpl = require('./tpl'),
-  filterableListController = require('../controllers/filterable-list');
+  filterableListController = require('../controllers/filterable-list'),
+  kilnHideClass = 'kiln-hide';
 
 /**
  * add filtered items
  * note: items may be an array of strings, or objects with id and title
  * @param {array} items
+ * @param {object} options
  * @returns {Element}
  */
-function addFilteredItems(items) {
+function addFilteredItems(items, options) {
   var wrapper = tpl.get('.filtered-items-template'),
     listEl = dom.find(wrapper, 'ul');
 
   _.each(items, function (item) {
     var itemEl = tpl.get('.filtered-item-template'),
-      listItem = dom.find(itemEl, 'li');
+      listItem = dom.find(itemEl, 'li'),
+      listItemTitle = dom.find(itemEl, '.filtered-item-title');
 
-    // add name and label to each list item
+    // add title and id to each list item
+    // note: title is set inside a specific span, whereas
+    // id is set on the list item itself
     if (_.isString(item)) {
-      listItem.innerHTML = label(item);
+      listItemTitle.innerHTML = label(item);
       listItem.setAttribute('data-item-id', item);
     } else {
-      listItem.innerHTML = item.title;
+      listItemTitle.innerHTML = item.title; // allows html
       listItem.setAttribute('data-item-id', item.id);
     }
+
+    // 'remove' button
+    if (options.remove) {
+      dom.find(listItem, '.filtered-item-remove').classList.remove(kilnHideClass);
+    }
+
     // add it to the list
     listEl.appendChild(itemEl);
   });
@@ -42,14 +53,16 @@ function addFilteredItems(items) {
  */
 function create(items, options) {
   var inputEl = tpl.get('.filtered-input-template'),
-    itemsEl = addFilteredItems(items), // todo: remove, reorder, settings options
-    el = dom.create('<div class="filterable-list-wrapper"></div>');
+    el = dom.create('<div class="filterable-list-wrapper"></div>'),
+    itemsEl;
 
   if (!_.isArray(items) || !_.isObject(options)) {
     throw new Error('Filterable lists need items and an options object!');
   } else if (!options.click) {
     throw new Error('Filterable lists need a click function!');
   }
+
+  itemsEl = addFilteredItems(items, options), // todo: reorder and settings options
 
   el.appendChild(inputEl);
   el.appendChild(itemsEl);

--- a/services/filterable-list.js
+++ b/services/filterable-list.js
@@ -38,6 +38,11 @@ function addFilteredItems(items, options) {
       dom.find(listItem, '.filtered-item-remove').classList.remove(kilnHideClass);
     }
 
+    // 'settings' button
+    if (options.settings) {
+      dom.find(listItem, '.filtered-item-settings').classList.remove(kilnHideClass);
+    }
+
     // add it to the list
     listEl.appendChild(itemEl);
   });
@@ -62,7 +67,7 @@ function create(items, options) {
     throw new Error('Filterable lists need a click function!');
   }
 
-  itemsEl = addFilteredItems(items, options), // todo: reorder and settings options
+  itemsEl = addFilteredItems(items, options);
 
   el.appendChild(inputEl);
   el.appendChild(itemsEl);

--- a/services/filterable-list.test.js
+++ b/services/filterable-list.test.js
@@ -6,6 +6,14 @@ var dirname = __dirname.split('/').pop(),
   dom = require('@nymag/dom'),
   _ = require('lodash');
 
+function stubFilterableItemTemplate() {
+  // wrapper divs to simulate doc fragments
+  return dom.create(`<div><li class="filtered-item">
+    <span class="filtered-item-title"></span>
+    <button class="filtered-item-remove kiln-hide" title="Remove">X</button>
+  </li></div>`);
+}
+
 describe(dirname, function () {
   describe(filename, function () {
     var sandbox;
@@ -16,7 +24,7 @@ describe(dirname, function () {
       sandbox.stub(tpl, 'get');
       tpl.get.withArgs('.filtered-input-template').returns(dom.create('<input class="filtered-input" />'));
       tpl.get.withArgs('.filtered-items-template').returns(dom.create('<div><ul class="filtered-items"></div>')); // wrapper divs to simulate doc fragments
-      tpl.get.withArgs('.filtered-item-template').returns(dom.create('<div><li class="filtered-item"></div>')); // wrapper divs to simulate doc fragments
+      tpl.get.withArgs('.filtered-item-template').returns(stubFilterableItemTemplate());
     });
 
     afterEach(function () {
@@ -61,21 +69,27 @@ describe(dirname, function () {
       it('creates labels for string arrays', function () {
         var el = fn(['foo-bar'], { click: _.noop });
 
-        expect(dom.find(el, '.filtered-item').innerHTML).to.equal('Foo Bar');
+        expect(dom.find(el, '.filtered-item-title').innerHTML).to.equal('Foo Bar');
         expect(dom.find(el, '.filtered-item').getAttribute('data-item-id')).to.equal('foo-bar');
       });
 
       it('uses title and id of object arrays', function () {
         var el = fn([{ title: 'Foo Bar', id: 'foo-bar' }], { click: _.noop });
 
-        expect(dom.find(el, '.filtered-item').innerHTML).to.equal('Foo Bar');
+        expect(dom.find(el, '.filtered-item-title').innerHTML).to.equal('Foo Bar');
         expect(dom.find(el, '.filtered-item').getAttribute('data-item-id')).to.equal('foo-bar');
       });
 
       it('allows html in title', function () {
         var el = fn([{ title: 'Foo <em>Bar</em>', id: 'foo-bar' }], { click: _.noop });
 
-        expect(dom.find(el, '.filtered-item').innerHTML).to.equal('Foo <em>Bar</em>');
+        expect(dom.find(el, '.filtered-item-title').innerHTML).to.equal('Foo <em>Bar</em>');
+      });
+
+      it('adds remove buttons if options.remove is set', function () {
+        var el = fn([{ title: 'Foo <em>Bar</em>', id: 'foo-bar' }], { click: _.noop, remove: _.noop });
+
+        expect(dom.find(el, '.filtered-item-remove')).to.not.equal(null);
       });
     });
   });

--- a/services/filterable-list.test.js
+++ b/services/filterable-list.test.js
@@ -10,6 +10,7 @@ function stubFilterableItemTemplate() {
   // wrapper divs to simulate doc fragments
   return dom.create(`<div><li class="filtered-item">
     <span class="filtered-item-title"></span>
+    <button class="filtered-item-settings kiln-hide" title="Settings">*</button>
     <button class="filtered-item-remove kiln-hide" title="Remove">X</button>
   </li></div>`);
 }
@@ -89,7 +90,13 @@ describe(dirname, function () {
       it('adds remove buttons if options.remove is set', function () {
         var el = fn([{ title: 'Foo <em>Bar</em>', id: 'foo-bar' }], { click: _.noop, remove: _.noop });
 
-        expect(dom.find(el, '.filtered-item-remove')).to.not.equal(null);
+        expect(dom.find(el, '.filtered-item-remove').classList.contains('kiln-hide')).to.equal(false);
+      });
+
+      it('adds settings buttons if options.settings is set', function () {
+        var el = fn([{ title: 'Foo <em>Bar</em>', id: 'foo-bar' }], { click: _.noop, settings: _.noop });
+
+        expect(dom.find(el, '.filtered-item-settings').classList.contains('kiln-hide')).to.equal(false);
       });
     });
   });

--- a/services/pane.test.js
+++ b/services/pane.test.js
@@ -66,6 +66,7 @@ function stubFilterableItemTemplate() {
   // wrapper divs to simulate doc fragments
   return dom.create(`<div><li class="filtered-item">
     <span class="filtered-item-title"></span>
+    <button class="filtered-item-settings kiln-hide" title="Settings">*</button>
     <button class="filtered-item-remove kiln-hide" title="Remove">X</button>
   </li></div>`);
 }

--- a/services/pane.test.js
+++ b/services/pane.test.js
@@ -62,6 +62,14 @@ function stubErrorsTemplate() {
   </div>`);
 }
 
+function stubFilterableItemTemplate() {
+  // wrapper divs to simulate doc fragments
+  return dom.create(`<div><li class="filtered-item">
+    <span class="filtered-item-title"></span>
+    <button class="filtered-item-remove kiln-hide" title="Remove">X</button>
+  </li></div>`);
+}
+
 describe(dirname, function () {
   describe(filename, function () {
     var sandbox, getTemplate;
@@ -84,7 +92,7 @@ describe(dirname, function () {
       getTemplate.withArgs('.publish-errors-template').returns(stubErrorsTemplate());
       getTemplate.withArgs('.filtered-input-template').returns(dom.create('<input class="filtered-input" />'));
       getTemplate.withArgs('.filtered-items-template').returns(dom.create('<div><ul class="filtered-items"></div>')); // wrapper divs to simulate doc fragments
-      getTemplate.withArgs('.filtered-item-template').returns(dom.create('<div><li class="filtered-item"></div>')); // wrapper divs to simulate doc fragments
+      getTemplate.withArgs('.filtered-item-template').returns(stubFilterableItemTemplate());
     });
 
     afterEach(function () {

--- a/styleguide/_buttons.scss
+++ b/styleguide/_buttons.scss
@@ -82,3 +82,46 @@
 
 // scheduled button
 // $orange (filled only)
+
+// mixin for creating the selector icons and list icons
+@mixin icon-button($fill, $size) {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin: 0;
+  outline: none;
+  color: $fill;
+  padding: 6px 8px;
+
+  // set icon sizes
+  svg {
+    width: $size;
+    height: $size;
+  }
+
+  // set fill color
+  svg,
+  svg * {
+    fill: $fill;
+    transition: 150ms fill ease-out;
+  }
+
+  // subtle hover state
+  &:hover svg,
+  &:hover svg * {
+    fill: darken($fill, 5%);
+    transition: 150ms fill ease-out;
+  }
+
+  // subtle active state
+  &:active svg,
+  &:active svg * {
+    fill: darken($fill, 10%);
+    transition: 50ms fill ease-out;
+  }
+
+  // note: hover and active states are different than our regular outlined buttons,
+  // since the border-radius is applied to their parent elements
+  // (which means we can't set the background-color for each button without
+  // doing a bunch of logic to set their border radii)
+}

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -1,6 +1,7 @@
 @import 'colors';
 @import 'typography';
 @import 'layers';
+@import 'buttons';
 
 // selector offsets, for the selector outline
 $offset-width: 10px;
@@ -25,49 +26,6 @@ $layout-color: $purple;
 $layout-bg-color: $purple-50;
 $layout-parent-color: $purple-75;
 $layout-parent-bg-color: $purple-25;
-
-// mixin for creating the selector icons
-@mixin selector-icon($fill, $size) {
-  background: none;
-  border: none;
-  cursor: pointer;
-  margin: 0;
-  outline: none;
-  color: $fill;
-  padding: 6px 8px;
-
-  // set icon sizes
-  svg {
-    width: $size;
-    height: $size;
-  }
-
-  // set fill color
-  svg,
-  svg * {
-    fill: $fill;
-    transition: 150ms fill ease-out;
-  }
-
-  // subtle hover state
-  &:hover svg,
-  &:hover svg * {
-    fill: darken($fill, 5%);
-    transition: 150ms fill ease-out;
-  }
-
-  // subtle active state
-  &:active svg,
-  &:active svg * {
-    fill: darken($fill, 10%);
-    transition: 50ms fill ease-out;
-  }
-
-  // note: hover and active states are different than our regular outlined buttons,
-  // since the border-radius is applied to their parent elements
-  // (which means we can't set the background-color for each button without
-  // doing a bunch of logic to set their border radii)
-}
 
 // component element needs to be position: relative for the selectors to display
 .component-selector-wrapper {
@@ -163,24 +121,24 @@ $layout-parent-bg-color: $purple-25;
 .selected-info-parent,
 .selected-action-settings,
 .selected-action-delete {
-  @include selector-icon($layout-color, $action-icon-small);
+  @include icon-button($layout-color, $action-icon-small);
 }
 
 .kiln-page-area .selected-label,
 .kiln-page-area .selected-info-parent,
 .kiln-page-area .selected-action-settings,
 .kiln-page-area .selected-action-delete {
-  @include selector-icon($page-color, $action-icon-small);
+  @include icon-button($page-color, $action-icon-small);
 }
 
 // add button is larger
 .selected-add,
 .selected-replace {
-  @include selector-icon($layout-color, $action-icon-large);
+  @include icon-button($layout-color, $action-icon-large);
 }
 .kiln-page-area .selected-add,
 .kiln-page-area .selected-replace {
-  @include selector-icon($page-color, $action-icon-large);
+  @include icon-button($page-color, $action-icon-large);
 }
 
 // set a border on parent, settings, and delete
@@ -215,7 +173,7 @@ $layout-parent-bg-color: $purple-25;
 
   .selected-label,
   .selected-action-settings {
-    @include selector-icon($layout-parent-color, $action-icon-small);
+    @include icon-button($layout-parent-color, $action-icon-small);
   }
 
   // set a border on settings instead of its container,
@@ -243,7 +201,7 @@ $layout-parent-bg-color: $purple-25;
 
   .selected-label,
   .selected-action-settings {
-    @include selector-icon($page-parent-color, $action-icon-small);
+    @include icon-button($page-parent-color, $action-icon-small);
   }
 
   // set a border on settings instead of its container,

--- a/styleguide/filterable-list.scss
+++ b/styleguide/filterable-list.scss
@@ -1,6 +1,7 @@
 @import 'colors';
 @import 'typography';
 @import 'inputs';
+@import 'buttons';
 
 .filterable-list-wrapper {
   width: 100%;
@@ -24,14 +25,27 @@
 }
 
 .filterable-list-wrapper .filtered-item {
-  @include primary-text();
-
+  align-items: center;
   cursor: pointer;
+  display: flex;
+  justify-content: flex-start;
   line-height: 16px;
   list-style: none;
   margin: 0;
   padding: 15px 0;
   width: 100%;
+}
+
+.filterable-list-wrapper .filtered-item-title {
+  @include primary-text();
+
+  flex: 1 0 auto;
+}
+
+.filterable-list-wrapper .filtered-item-remove {
+  @include icon-button($black-75, 24px);
+
+  flex: 0 0 auto;
 }
 
 .filterable-list-wrapper .filtered-item.filtered {

--- a/styleguide/filterable-list.scss
+++ b/styleguide/filterable-list.scss
@@ -36,18 +36,6 @@
   width: 100%;
 }
 
-.filterable-list-wrapper .filtered-item-title {
-  @include primary-text();
-
-  flex: 1 0 auto;
-}
-
-.filterable-list-wrapper .filtered-item-remove {
-  @include icon-button($black-75, 24px);
-
-  flex: 0 0 auto;
-}
-
 .filterable-list-wrapper .filtered-item.filtered {
   display: none;
 }
@@ -66,6 +54,21 @@
 .filterable-list-wrapper .filtered-item.active {
   border-bottom: 2px solid $blue;
 }
+
+.filterable-list-wrapper .filtered-item-title {
+  @include primary-text();
+
+  flex: 1 0 auto;
+}
+
+.filterable-list-wrapper .filtered-item-remove {
+  @include icon-button($black-75, 24px);
+
+  flex: 0 0 auto;
+  padding: 0;
+}
+
+// animations
 
 @keyframes shake {
   0%, 100% {transform: translateX(0);}

--- a/styleguide/filterable-list.scss
+++ b/styleguide/filterable-list.scss
@@ -61,10 +61,12 @@
   flex: 1 0 auto;
 }
 
-.filterable-list-wrapper .filtered-item-remove {
+.filterable-list-wrapper .filtered-item-remove,
+.filterable-list-wrapper .filtered-item-settings {
   @include icon-button($black-75, 24px);
 
   flex: 0 0 auto;
+  margin-left: 5px;
   padding: 0;
 }
 

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -164,6 +164,7 @@
     <template class="filtered-item-template">
       <li class="filtered-item" tabindex="0">
         <span class="filtered-item-title"></span>
+        <button class="filtered-item-settings kiln-hide" title="Settings">{% include 'public/media/components/clay-kiln/component-bar-settings.svg' %}</button>
         <button class="filtered-item-remove kiln-hide" title="Remove">{% include 'public/media/components/clay-kiln/component-bar-delete.svg' %}</button>
       </li>
     </template>

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -162,7 +162,10 @@
     </template>
 
     <template class="filtered-item-template">
-      <li class="filtered-item" tabindex="0"></li>
+      <li class="filtered-item" tabindex="0">
+        <span class="filtered-item-title"></span>
+        <button class="filtered-item-remove kiln-hide" title="Remove">{% include 'public/media/components/clay-kiln/component-bar-delete.svg' %}</button>
+      </li>
     </template>
 
     {# template: component selector #}


### PR DESCRIPTION
* settings
* remove

Note: remove has a confirmation, similarly to the remove button in component selectors.

Note: Also there's no keyboard shortcut for remove, partially because we don't have one for component selectors but partially because I can't distinguish between "pressing enter to confirm" and "pressing enter on a list item"