### PR TITLE
display published state for non-article pages

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -68,7 +68,7 @@ EditorToolbar = function (el) {
       state.openDynamicSchedule(res.scheduledAt, res.publishedUrl);
     } else if (res.published) {
       state.toggleButton('published', true);
-      progress.open('publish', `Page is currently live: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
+      progress.open('publish', `Page is currently published: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
     }
   });
 };

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -76,7 +76,7 @@ function getArticleReference(page) {
 }
 
 /**
- * get article date
+ * get article date, if it exists
  * @param {object} pageData
  * @returns {Promise} date
  */
@@ -84,10 +84,10 @@ function getArticleDate(pageData) {
   var article = getArticleReference(pageData);
 
   if (!article) {
-    throw new Error('No article in page!');
+    return null;
+  } else {
+    return edit.getDataOnly(article).then(res => res.date);
   }
-
-  return edit.getDataOnly(article).then(res => res.date);
 }
 
 /**
@@ -111,7 +111,7 @@ function getPublished(publishedUri) {
       });
     })
     .catch(function () {
-      // no url, or the page can't be loaded, or the article has no date
+      // no url, or the page can't be loaded
       // or something else went wrong somewhere!
       return {
         published: false,

--- a/services/pane.js
+++ b/services/pane.js
@@ -215,9 +215,9 @@ function createPublishMessages(res) {
   if (res.published) {
     stateMessage = dom.find(messages, '.publish-state-message');
     if (stateMessage && res.publishedAt) {
-      stateMessage.innerHTML = `Published ${state.formatTime(res.publishedAt)}`;
+      stateMessage.innerHTML = `Published ${state.formatTime(res.publishedAt)}.`;
     } else if (stateMessage) {
-      stateMessage.innerHTML = 'Currently published';
+      stateMessage.innerHTML = 'Page is currently published.';
     }
   }
 

--- a/services/pane.js
+++ b/services/pane.js
@@ -214,8 +214,10 @@ function createPublishMessages(res) {
 
   if (res.published) {
     stateMessage = dom.find(messages, '.publish-state-message');
-    if (stateMessage) {
+    if (stateMessage && res.publishedAt) {
       stateMessage.innerHTML = `Published ${state.formatTime(res.publishedAt)}`;
+    } else if (stateMessage) {
+      stateMessage.innerHTML = 'Currently published';
     }
   }
 


### PR DESCRIPTION
When getting the page state, we were failing the published check if a page didn't have an article. Instead, simply fall back to saying "Page is currently published." Also, this makes the language consistent between the state message and the publish pane's info message.

![screen shot 2016-08-08 at 6 05 11 pm](https://cloud.githubusercontent.com/assets/447522/17498023/b313c92e-5d92-11e6-8cb9-9bac41a5ef71.png)

![screen shot 2016-08-08 at 6 05 50 pm](https://cloud.githubusercontent.com/assets/447522/17498031/c6538d26-5d92-11e6-82c6-c97e306ac804.png)
