### PR TITLE
fixed syntax error with prevRef

### DIFF
--- a/services/pane.js
+++ b/services/pane.js
@@ -511,7 +511,7 @@ function openAddComponent(components, options) {
   var header = 'Add Component',
     innerEl = filterableList.create(components, {
       click: function (id) {
-        return addComponent(options.pane, options.field, id, options.prevRef)
+        return addComponent(options.pane, options.field, id, options.ref)
           .then(() => close()); // only close pane if we added successfully
       }
     });


### PR DESCRIPTION
When I moved add component to use the filterable list, I thought `options.prevRef` was the property for the component we wanted to add things after. It's actually just `options.ref`.