### PR TITLE
use native fetch + polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-map2": "^1.2.1",
     "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.7.0"
+    "watchify": "^3.7.0",
+    "whatwg-fetch": "^1.0.0"
   }
 }

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -136,7 +136,7 @@ function send(options) {
   // add credentials. this tells fetch to pass along cookies, incl. auth
   options.credentials = 'same-origin';
 
-  return rest.send(options.url, options).then(checkStatus);
+  return rest.send(uriToUrl(options.url), options).then(checkStatus);
 }
 
 /**
@@ -256,7 +256,7 @@ function save(uri, data) {
   return send(addJsonHeader({
     method: 'PUT',
     url: uri,
-    data: data
+    body: JSON.stringify(data)
   })).then(expectJSONResult);
 }
 
@@ -272,7 +272,7 @@ function saveForHTML(uri, data) {
   return send(addJsonHeader({
     method: 'PUT',
     url: uri + extHtml + editMode,
-    data: data
+    body: JSON.stringify(data)
   })).then(expectHTMLResult(uri));
 }
 
@@ -287,7 +287,7 @@ function saveText(uri, data) {
   return send(addTextHeader({
     method: 'PUT',
     url: uri,
-    data: data
+    body: data
   })).then(expectTextResult);
 }
 
@@ -304,7 +304,7 @@ function create(uri, data) {
   return send(addJsonHeader({
     method: 'POST',
     url: uri,
-    data: data
+    body: JSON.stringify(data)
   })).then(expectJSONResult);
 }
 

--- a/services/edit/db.test.js
+++ b/services/edit/db.test.js
@@ -1,16 +1,24 @@
 var lib = require('./db'),
   sinon = require('sinon'),
-  site = require('./../site');
+  site = require('./../site'),
+  rest = require('./rest');
 
 describe('db service', function () {
   var sandbox;
 
   function respond(data) {
-    sandbox.server.respondWith(function (req) { req.respond(200, null, data); });
+    rest.send.returns(Promise.resolve({
+      status: 200,
+      json: () => Promise.resolve(JSON.parse(data)),
+      text: () => Promise.resolve(data)
+    }));
   }
 
   function respondError(code) {
-    sandbox.server.respondWith(function (req) { req.respond(code, null, ''); });
+    rest.send.returns(Promise.resolve({
+      status: code,
+      statusText: 'nope'
+    }));
   }
 
   /**
@@ -60,8 +68,7 @@ describe('db service', function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    sandbox.useFakeServer();
-    sandbox.server.autoRespond = true;
+    sandbox.stub(rest, 'send');
 
     sandbox.stub(site);
     site.addProtocol.returnsArg(0);

--- a/services/edit/rest.js
+++ b/services/edit/rest.js
@@ -1,3 +1,3 @@
 import 'whatwg-fetch';
 
-module.exports.send = fetch; // either polyfill or native, depending on browser
+module.exports.send = fetch.bind(window); // either polyfill or native, depending on browser

--- a/services/edit/rest.js
+++ b/services/edit/rest.js
@@ -1,0 +1,3 @@
+import 'whatwg-fetch';
+
+module.exports.send = fetch; // either polyfill or native, depending on browser


### PR DESCRIPTION
This updates kiln to use native `fetch` (falling back to a polyfill on safari), rather than old-school `XMLHttpRequest`. It simplifies our codebase quite a bit, and should give us a nice little speed increase as well.