### PR TITLE
adds startCase function that doesn't strip dash separator

### DIFF
--- a/behaviors/site-specific-select.js
+++ b/behaviors/site-specific-select.js
@@ -9,7 +9,7 @@ var _ = require('lodash'),
  */
 function createOptions(options) {
   return _.map(options, function (option) {
-    return `<option value="${option}">${ _.startCase(option) || 'None' }</option>`;
+    return `<option value="${option}">${ startCase(option) || 'None' }</option>`;
   }).join('\n');
 }
 
@@ -27,6 +27,19 @@ function createField(name, options) {
       </select>
     </label>
   `);
+}
+
+/**
+ * Capitalize first character of a string while persisting dash separator
+ * @param {string} str
+ * @return {string}
+ */
+function startCase(str) {
+  return _.reduce(_.words(str), function (result, value) {
+    var separator = str[str.indexOf(value) - 1] || '';
+
+    return result + separator + _.upperFirst(value);
+  }, '');
 }
 
 /**

--- a/behaviors/site-specific-select.test.js
+++ b/behaviors/site-specific-select.test.js
@@ -7,7 +7,7 @@ var dirname = __dirname.split('/').pop(),
 
 describe(dirname, function () {
   describe(filename, function () {
-    var options = ['apple', 'banana', 'cantaloupe'],
+    var options = ['squishy-apple', 'mushy banana', 'cantaloupe'],
       sandbox;
 
     beforeEach(function () {
@@ -50,8 +50,8 @@ describe(dirname, function () {
       expect(select.getAttribute('rv-field')).to.eql('foo');
       expect(select.getAttribute('rv-value')).to.eql('foo.data.value');
       expect(selectOptions.length).to.eql(3);
-      expect(firstOption.value).to.eql('apple');
-      expect(firstOption.textContent).to.eql('Apple');
+      expect(firstOption.value).to.eql('squishy-apple');
+      expect(firstOption.textContent).to.eql('Squishy-Apple');
     });
 
     it('matches site slug', function () {


### PR DESCRIPTION
https://trello.com/c/mKd3yjBx/39-content-channels

This will maintain dash separators in content channel names.