### PR TITLE
custom url tab

### DIFF
--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -155,9 +155,26 @@ module.exports = function () {
 
     onCustomUrl: function (e) {
       var val = dom.find(this.customUrlForm, 'input').value,
-        url = db.uriToUrl(site.get('prefix') + val);
+        url;
 
       e.preventDefault(); // stop form submit
+
+      // make sure we're not adding the site prefix twice!
+      // handle both /paths and http://full-urls
+      if (val.match(/^http/i)) {
+        // full url
+        url = val;
+      } else if (val.match(/^\/\S/i)) {
+        // already starts with a slash
+        url = db.uriToUrl(site.get('prefix') + val);
+      } else if (val.match(/^\S/i)) {
+        // add the slash ourselves
+        url = db.uriToUrl(site.get('prefix') + '/' + val);
+      } else if (val === '') {
+        // unset custom url
+        url === '';
+      }
+
       pane.close();
       progress.start('page');
 

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -91,6 +91,15 @@ function getArticleDate(pageData) {
 }
 
 /**
+ * get custom url, if it exists
+ * @param {object} pageData
+ * @returns {string|undefined}
+ */
+function getCustomPageUrl(pageData) {
+  return pageData.customUrl || null;
+}
+
+/**
  * get published state
  * @param {string} publishedUri
  * @returns {Promise}
@@ -121,6 +130,15 @@ function getPublished(publishedUri) {
     });
 }
 
+function getLatest(uri) {
+  return db.get(uri)
+    .then(function (pageData) {
+      return {
+        customUrl: getCustomPageUrl(pageData)
+      };
+    });
+}
+
 /**
  * get scheduled/published state of the page
  * used when toolbar inits and when publish pane is opened
@@ -131,9 +149,10 @@ function getPageState() {
 
   return Promise.all([
     getScheduled(pageUri + '@scheduled'),
-    getPublished(pageUri + '@published')
+    getPublished(pageUri + '@published'),
+    getLatest(pageUri)
   ]).then(function (promises) {
-    return _.assign({}, promises[0], promises[1]);
+    return _.assign({}, promises[0], promises[1], promises[2]);
   });
 }
 

--- a/services/page-state.test.js
+++ b/services/page-state.test.js
@@ -47,29 +47,40 @@ describe(dirname, function () {
       it('gets scheduled when not published', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
         get.withArgs(publishedRef).returns(Promise.reject());
-        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: false, publishedUrl: null, publishedAt: null }));
+        get.withArgs(fakePageUri).returns(Promise.resolve({}));
+        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: false, publishedUrl: null, publishedAt: null, customUrl: null }));
       });
 
       it('gets published when not scheduled', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
         get.withArgs(publishedRef).returns(Promise.resolve(fakeInstanceData));
+        get.withArgs(fakePageUri).returns(Promise.resolve({}));
         getDataOnly.withArgs(fakeArticleRef).returns(Promise.resolve(fakeArticle));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
-        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: true, publishedUrl: fakeUrl, publishedAt: new Date(0) }));
+        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: true, publishedUrl: fakeUrl, publishedAt: new Date(0), customUrl: null }));
       });
 
       it('gets scheduled and published', function () {
         get.withArgs(scheduleRef).returns(Promise.resolve({ at: 1 }));
         get.withArgs(publishedRef).returns(Promise.resolve(fakeInstanceData));
+        get.withArgs(fakePageUri).returns(Promise.resolve({}));
         getDataOnly.withArgs(fakeArticleRef).returns(Promise.resolve(fakeArticle));
         getHead.withArgs(fakeUri).returns(Promise.resolve(true));
-        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: true, publishedUrl: fakeUrl, publishedAt: new Date(0) }));
+        return fn().then(expectState({ scheduled: true, scheduledAt: 1, published: true, publishedUrl: fakeUrl, publishedAt: new Date(0), customUrl: null }));
       });
 
       it('gets neither scheduled nor published', function () {
         get.withArgs(scheduleRef).returns(Promise.reject());
         get.withArgs(publishedRef).returns(Promise.reject());
-        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: false, publishedUrl: null, publishedAt: null }));
+        get.withArgs(fakePageUri).returns(Promise.resolve({}));
+        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: false, publishedUrl: null, publishedAt: null, customUrl: null }));
+      });
+
+      it('gets custom url', function () {
+        get.withArgs(scheduleRef).returns(Promise.reject());
+        get.withArgs(publishedRef).returns(Promise.reject());
+        get.withArgs(fakePageUri).returns(Promise.resolve({ customUrl: 'http://domain.com/foo' }));
+        return fn().then(expectState({ scheduled: false, scheduledAt: null, published: false, publishedUrl: null, publishedAt: null, customUrl: 'http://domain.com/foo' }));
       });
     });
 

--- a/services/pane.js
+++ b/services/pane.js
@@ -285,6 +285,22 @@ function createPublishActions(res) {
 }
 
 /**
+ * create the form to set a custom url
+ * @param {object} res which may contain customUrl
+ * @returns {Element}
+ */
+function createLocationForm(res) {
+  const form = tpl.get('.custom-url-form-template'),
+    val = res.customUrl;
+
+  if (val) {
+    dom.find(form, '.custom-url-input').value = val;
+  }
+
+  return form;
+}
+
+/**
  * open publish pane
  * @param {object} validation
  * @param {Object[]} validation.errors
@@ -292,46 +308,57 @@ function createPublishActions(res) {
  * @returns {Promise}
  */
 function openPublish(validation) {
-  var pubHeader = 'Publish',
-    pubContent = document.createDocumentFragment(),
-    healthContent = document.createDocumentFragment(),
-    healthHeader, el;
+  var pubContent = document.createDocumentFragment(),
+    locationContent = document.createDocumentFragment(),
+    healthContent = document.createDocumentFragment();
 
   return state.get().then(function (res) {
-    // append message and actions to the doc fragment
+    var tabs, dynamicTab, el;
+
+    // append publish message and actions to the doc fragment
     pubContent.appendChild(createUndoActions(res));
     pubContent.appendChild(createPublishMessages(res));
     pubContent.appendChild(createPublishActions(res));
 
+    locationContent.appendChild(createLocationForm(res));
+
     // add dynamic pane with validation
     healthContent.appendChild(createPublishValidation(validation));
-    healthHeader = createHealthHeader(validation);
 
     // if there are errors, make the health tab active when the pane opens
     // and disable the publish tab
     if (_.get(validation, 'errors.length')) {
-      // create the root pane element
-      el = open([{
-        header: pubHeader,
+      // publish is disabled
+      tabs = [{
+        header: 'Publish',
         content: pubContent,
         disabled: true
-      }], {
-        // dynamic health tab
-        header: healthHeader,
+      }, {
+        header: 'Location',
+        content: locationContent
+      }];
+      dynamicTab = {
+        header: createHealthHeader(validation),
         content: healthContent,
-        active: true
-      });
+        active: true // health tab is active when pane opens
+      };
     } else {
-      // create the root pane element like normal
-      el = open([{
-        header: pubHeader,
-        content: pubContent
-      }], {
-        // dynamic health tab
-        header: healthHeader,
+      tabs = [{
+        header: 'Publish',
+        content: pubContent,
+        active: true // publish tab is active when pane opens
+      }, {
+        header: 'Location',
+        content: locationContent
+      }];
+      dynamicTab = {
+        header: createHealthHeader(validation),
         content: healthContent
-      });
+      };
     }
+
+    // create pane!
+    el = open(tabs, dynamicTab);
 
     // init controller for publish pane
     ds.controller('publish-pane', publishPaneController);

--- a/services/pane.js
+++ b/services/pane.js
@@ -294,7 +294,9 @@ function createLocationForm(res) {
     val = res.customUrl;
 
   if (val) {
-    dom.find(form, '.custom-url-input').value = val;
+    // remove the site prefix when displaying the url in the form
+    // it'll be added when saving the form
+    dom.find(form, '.custom-url-input').value = val.replace(db.uriToUrl(site.get('prefix')), '');
   }
 
   return form;

--- a/services/pane.test.js
+++ b/services/pane.test.js
@@ -47,6 +47,14 @@ function stubPublishTemplate() {
   </div>`);
 }
 
+function stubCustomUrlTemplate() {
+  return dom.create(`<form class="custom-url-form">
+    <label for="custom-url" class="custom-url-message">Designate a custom URL for this page. This should only be used for special cases.</p>
+    <input id="custom-url" class="custom-url-input" type="text" placeholder="/special-page.html" />
+    <button type="submit" class="custom-url-submit">Save Location</button>
+  </form>`);
+}
+
 function stubPreviewActionsTemplate() {
   return dom.create(`<div class="preview-actions actions">
     <form class="preview-link">
@@ -100,6 +108,7 @@ describe(dirname, function () {
       getTemplate.withArgs('.publish-error-message-template').returns(dom.create('<div>ERROR MESSAGE</div>'));
       getTemplate.withArgs('.publish-warning-message-template').returns(dom.create('<div>WARNING MESSAGE</div>'));
       getTemplate.withArgs('.publish-errors-template').returns(stubErrorsTemplate());
+      getTemplate.withArgs('.custom-url-form-template').returns(stubCustomUrlTemplate());
       getTemplate.withArgs('.filtered-input-template').returns(dom.create('<input class="filtered-input" />'));
       getTemplate.withArgs('.filtered-items-template').returns(dom.create('<div><ul class="filtered-items"></div>')); // wrapper divs to simulate doc fragments
       getTemplate.withArgs('.filtered-item-template').returns(stubFilterableItemTemplate());
@@ -293,6 +302,18 @@ describe(dirname, function () {
             preview: 'Bar'
           }]
         }]}).then(expectRegularPane);
+      });
+
+      it('adds custom url if it exists', function () {
+        getState.returns(Promise.resolve({ customUrl: 'http://domain.com/foo' }));
+        lib.close();
+
+        function expectCustomUrl() {
+          expect(document.querySelector('#pane-tab-2').innerHTML).to.equal('Location');
+          expect(document.querySelector('.pane-inner .custom-url-input').value).to.equal('/foo');
+        }
+
+        fn().then(expectCustomUrl);
       });
     });
 

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -413,6 +413,22 @@ $schedule-item-width: calc(50% - 8px);
   margin-left: 5px;
 }
 
+/* location tab */
+.kiln-toolbar-pane .custom-url-message {
+  @include secondary-text();
+}
+
+.kiln-toolbar-pane .custom-url-input {
+  @include input();
+
+  margin: 10px 0;
+}
+
+.kiln-toolbar-pane .custom-url-submit {
+  @include button-outlined();
+  @include full-width();
+}
+
 /* easter egg pane */
 
 .kiln-toolbar-pane .cats-ayb {

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -164,6 +164,14 @@
       <div class="warning-message">This page has some warnings. Please review before publishing.</div>
     </template>
 
+    <template class="custom-url-form-template">
+      <form class="custom-url-form">
+        <label for="custom-url" class="custom-url-message">Designate a custom URL for this page. This should only be used for special cases.</p>
+        <input id="custom-url" class="custom-url-input" type="text" placeholder="/special-page.html" />
+        <button type="submit" class="custom-url-submit">Save Location</button>
+      </form>
+    </template>
+
     {# generic filtered list template. used for the add component pane #}
     <template class="filtered-input-template">
       <input class="filtered-input" placeholder="Start typing to filter this list" />


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/OnMDeM3Q/18-custom-url)
* allows typing in custom urls
* will display if a page already has a custom url
* displays the path from the beginning slash
* allows paths with/without beginning slash, or full urls
* saved to page data
* uses same form ux as adding new pages to the pages list (discrete save action, page-colored success message, etc)

![screen shot 2016-08-12 at 1 51 43 pm](https://cloud.githubusercontent.com/assets/447522/17632236/4a724782-6095-11e6-9378-d8197231c2fc.png)
