### PR TITLE
handle docfragments in expectHTML

### DIFF
--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -178,10 +178,10 @@ function expectHTMLResult(uri) {
   return function (res) {
     return res.text().then(dom.create) // string -> elements
     .then(function (html) {
-      if (html.nodeType === 1) {
+      if (html.nodeType === html.ELEMENT_NODE) {
         // it's an element, add the uri
         html.setAttribute(references.referenceAttribute, uri);
-      } else if (html.nodeType === 11) {
+      } else if (html.nodeType === html.DOCUMENT_FRAGMENT_NODE) {
         // it's a document fragment, add the uri to the first child
         html.firstElementChild.setAttribute(references.referenceAttribute, uri);
       }

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -176,13 +176,15 @@ function expectJSONResult(res) {
  */
 function expectHTMLResult(uri) {
   return function (res) {
-    return res.text().then(function (body) {
-      // string -> elements
-      return dom.create(body);
-    })
+    return res.text().then(dom.create) // string -> elements
     .then(function (html) {
-      // add uri
-      html.setAttribute(references.referenceAttribute, uri);
+      if (html.nodeType === 1) {
+        // it's an element, add the uri
+        html.setAttribute(references.referenceAttribute, uri);
+      } else if (html.nodeType === 11) {
+        // it's a document fragment, add the uri to the first child
+        html.firstElementChild.setAttribute(references.referenceAttribute, uri);
+      }
       return html;
     });
   };

--- a/services/edit/db.test.js
+++ b/services/edit/db.test.js
@@ -281,7 +281,7 @@ describe('db service', function () {
 
     createUriBlockTests(fn);
 
-    it('returns data with schema', function () {
+    it('handles returned html', function () {
       respond('<div>ok</div>');
 
       return fn('foo').then(function (data) {
@@ -289,7 +289,15 @@ describe('db service', function () {
       });
     });
 
-    it('throws on bad data', function (done) {
+    it('handles returned full document', function () {
+      respond('<!DOCTYPE html><html><head></head><body><div>ok</div></body></html>');
+
+      return fn('foo').then(function (data) {
+        expect(data.getAttribute('data-uri')).to.deep.equal('foo');
+      });
+    });
+
+    it('throws if error', function (done) {
       respond(new Error('bad data'));
 
       fn('foo').then(function () {

--- a/services/edit/db.test.js
+++ b/services/edit/db.test.js
@@ -290,9 +290,7 @@ describe('db service', function () {
     });
 
     it('throws on bad data', function (done) {
-      var data = 'jkfdlsa';
-
-      respond(data);
+      respond(new Error('bad data'));
 
       fn('foo').then(function () {
         done('should throw');

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -112,7 +112,8 @@ function save(data) {
           window.kiln.trigger('save', data);
           return savedData;
         })
-        .catch(function () {
+        .catch(function (e) {
+          console.error(e.message, e.stack);
           progress.done('error');
           progress.open('error', 'A server error occured. Please try again.', true);
         });


### PR DESCRIPTION
* log error messages when `edit.save` hits an error
* handle document fragments in `db.expectHTML`
* thanks to @vicfriedman for finding this bug!