### PR TITLE
component finder pane

### DIFF
--- a/controllers/filterable-list.js
+++ b/controllers/filterable-list.js
@@ -221,7 +221,6 @@ module.exports = function () {
         id = currentItem.getAttribute('data-item-id');
 
       e.preventDefault();
-      console.log(e.currentTarget)
       e.stopPropagation();
       this.options.click(id, currentItem);
     },

--- a/controllers/filterable-list.js
+++ b/controllers/filterable-list.js
@@ -102,7 +102,7 @@ function addDragula(el, reorder) {
   drag.on('drop', function (selectedItem, container) {
     selectedItem.classList.remove(dragItemClass);
     container.classList.remove(dropAreaClass);
-    reorder(selectedItem.getAttribute('data-item-id'), getIndex(selectedItem, container), oldIndex);
+    reorder(selectedItem.getAttribute('data-item-id'), getIndex(selectedItem, container), oldIndex, selectedItem);
   });
 }
 
@@ -167,7 +167,7 @@ module.exports = function () {
       } else if (key === 'enter' && available.length === 1) {
         available[0].classList.remove('active');
         e.preventDefault();
-        this.options.click(available[0].getAttribute('data-item-id'));
+        this.options.click(available[0].getAttribute('data-item-id'), available[0]);
       } else if (key === 'enter') {
         input.classList.add('kiln-shake');
         setTimeout(() => input.classList.remove('kiln-shake'), 301); // length of the animation + 1
@@ -212,30 +212,35 @@ module.exports = function () {
         pane.close();
       } else if (key === 'enter') {
         e.preventDefault();
-        this.options.click(currentItem.getAttribute('data-item-id'));
+        this.options.click(currentItem.getAttribute('data-item-id'), currentItem);
       }
     },
 
     onItemClick: function (e) {
-      var id = e.currentTarget.parentElement.getAttribute('data-item-id');
+      var currentItem = e.currentTarget.parentElement,
+        id = currentItem.getAttribute('data-item-id');
 
       e.preventDefault();
-      this.options.click(id);
+      console.log(e.currentTarget)
+      e.stopPropagation();
+      this.options.click(id, currentItem);
     },
 
     onRemoveClick: function (e) {
-      var id = e.currentTarget.parentElement.getAttribute('data-item-id'),
+      var currentItem = e.currentTarget.parentElement,
+        id = currentItem.getAttribute('data-item-id'),
         confirm = window.confirm('Remove from this list?'); // eslint-disable-line
 
       if (confirm) {
-        this.options.remove(id);
+        this.options.remove(id, currentItem);
       }
     },
 
     onSettingsClick: function (e) {
-      var id = e.currentTarget.parentElement.getAttribute('data-item-id');
+      var currentItem = e.currentTarget.parentElement,
+        id = currentItem.getAttribute('data-item-id');
 
-      this.options.settings(id);
+      this.options.settings(id, currentItem);
     },
 
     onAddClick: function (e) {

--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -85,12 +85,9 @@ EditorToolbar.prototype = {
   },
 
   onComponentsClick: function () {
-    return focus.unfocus()
-      .then(pane.openComponents)
-      .catch(function () {
-        progress.done('error');
-        progress.open('error', 'Data could not be saved. Please review your open form.', true);
-      });
+    // note: we're explicitly NOT closing any current forms,
+    // because we don't want to unselect a currently selected component
+    return pane.openComponents();
   },
 
   onNewClick: function () {

--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -36,6 +36,7 @@ EditorToolbar = function (el) {
 
   events.add(this.toolbar, {
     '.user-icon click': 'onUserClick',
+    '.components click': 'onComponentsClick',
     '.new click': 'onNewClick',
     '.preview click': 'onPreviewClick',
     '.history click': 'onHistoryClick',
@@ -81,6 +82,15 @@ EditorToolbar.prototype = {
     // nothing yet
     e.preventDefault();
     e.stopPropagation();
+  },
+
+  onComponentsClick: function () {
+    return focus.unfocus()
+      .then(pane.openComponents)
+      .catch(function () {
+        progress.done('error');
+        progress.open('error', 'Data could not be saved. Please review your open form.', true);
+      });
   },
 
   onNewClick: function () {

--- a/media/component-finder.svg
+++ b/media/component-finder.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="21" viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg">
+  <g fill="#FFF" fill-rule="evenodd" opacity=".94"><path d="M0 11.111h9v9H0zM11.111 11.111h9v9h-9zM11.111 0h9v9h-9z"/></g>
+</svg>

--- a/services/components/select.js
+++ b/services/components/select.js
@@ -441,6 +441,7 @@ function handler(el, options) {
 // select and unselect
 module.exports.select = select;
 module.exports.unselect = unselect;
+module.exports.scrollToComponent = scrollToComponent;
 
 // decorators
 module.exports.when = when;

--- a/services/filterable-list.js
+++ b/services/filterable-list.js
@@ -89,11 +89,11 @@ function replaceInputPlaceholder(el, text) {
  * note: add an `active` class to specific list items to apply the "active" styles to that item
  * @param {array} items
  * @param {object} options
- * @param {function} options.click called with id when users click an item
+ * @param {function} options.click called with id and item element when users click an item
  * @param {function} [options.add] if passed in, shows add button below list. called with add button element when clicked
- * @param {function} [options.remove] if passed in, shows delete button on items. called with id when clicked
- * @param {function} [options.settings] if passed in, shows settings button on items. called with id when clicked
- * @param {function} [options.reorder] if passed in, shows grab icon on items and enables drag-drop. called with id, new index, and old index when items are reordered
+ * @param {function} [options.remove] if passed in, shows delete button on items. called with id and item element when clicked
+ * @param {function} [options.settings] if passed in, shows settings button on items. called with id and item element when clicked
+ * @param {function} [options.reorder] if passed in, shows grab icon on items and enables drag-drop. called with id, new index, old index, and item element when items are reordered
  * @param {string} [options.addTitle] if passed in, replaces default add button title
  * @param {string} [options.inputPlaceholder] if passed in, replaces default input placeholder
  * @returns {Element}

--- a/services/pane.js
+++ b/services/pane.js
@@ -596,18 +596,18 @@ function getName(el) {
 
 /**
  * open the component search pane
- * @returns {Promise}
  */
 function openComponents() {
   var searchHeader = 'Components',
     visibleComponents = _.filter(dom.findAll(`[${references.referenceAttribute}]`), showVisible).map(getName),
+    currentSelected = dom.find('.component-selector-wrapper.selected'),
     searchContent = filterableList.create(visibleComponents, {
       click: function (id, el) {
-        var currentActive = dom.find('.filtered-item.selected'),
+        var currentSelectedItem = dom.find('.filtered-item.selected'),
           component = dom.find(`[${references.referenceAttribute}="${id}"]`);
 
-        if (currentActive) {
-          currentActive.classList.remove('selected');
+        if (currentSelectedItem) {
+          currentSelectedItem.classList.remove('selected');
         }
 
         select.unselect();
@@ -615,9 +615,23 @@ function openComponents() {
         select.scrollToComponent(component);
         el.classList.add('selected');
       }
-    });
+    }),
+    currentItem, el;
 
-  return open([{header: searchHeader, content: searchContent}]);
+  if (currentSelected) {
+    currentItem = dom.find(searchContent, `[data-item-id="${currentSelected.getAttribute(references.referenceAttribute)}"]`);
+
+    currentItem.classList.add('selected');
+  }
+
+  el = open([{header: searchHeader, content: searchContent}]);
+
+  // once the pane is created, make sure it's scrolled so that the current item is visible
+  if (currentSelected) {
+    window.setTimeout(function () {
+      dom.find(el, '.pane-inner').scrollTop = currentItem.offsetTop + currentItem.offsetHeight - 35;
+    }, 300);
+  }
 }
 
 module.exports.close = close;

--- a/services/pane.js
+++ b/services/pane.js
@@ -598,7 +598,7 @@ function getName(el) {
  * open the component search pane
  */
 function openComponents() {
-  var searchHeader = 'Components',
+  var searchHeader = 'Find Component',
     visibleComponents = _.filter(dom.findAll(`[${references.referenceAttribute}]`), showVisible).map(getName),
     currentSelected = dom.find('.component-selector-wrapper.selected'),
     searchContent = filterableList.create(visibleComponents, {
@@ -614,7 +614,8 @@ function openComponents() {
         select.select(component);
         select.scrollToComponent(component);
         el.classList.add('selected');
-      }
+      },
+      inputPlaceholder: 'Search all visible components'
     }),
     currentItem, el;
 

--- a/services/pane.js
+++ b/services/pane.js
@@ -621,13 +621,15 @@ function openComponents() {
   if (currentSelected) {
     currentItem = dom.find(searchContent, `[data-item-id="${currentSelected.getAttribute(references.referenceAttribute)}"]`);
 
-    currentItem.classList.add('selected');
+    if (currentItem) {
+      currentItem.classList.add('selected');
+    }
   }
 
   el = open([{header: searchHeader, content: searchContent}]);
 
   // once the pane is created, make sure it's scrolled so that the current item is visible
-  if (currentSelected) {
+  if (currentSelected && currentItem) {
     window.setTimeout(function () {
       dom.find(el, '.pane-inner').scrollTop = currentItem.offsetTop + currentItem.offsetHeight - 35;
     }, 300);

--- a/styleguide/filterable-list.scss
+++ b/styleguide/filterable-list.scss
@@ -33,7 +33,6 @@
   line-height: 16px;
   list-style: none;
   margin: 0;
-  padding: 15px 0;
   width: 100%;
 }
 
@@ -70,11 +69,12 @@
   @include primary-text();
 
   flex: 1 0 auto;
+  padding: 15px 0;
 }
 
-.filtered-item.active .filtered-item-title,
-.dragula-list-item.active .filtered-item-title {
-  // some lists allow for denoting an "active" item
+.filtered-item.selected .filtered-item-title,
+.dragula-list-item.selected .filtered-item-title {
+  // some lists allow for denoting a "selected" item
   // e.g. spaces, component finder
   font-weight: 700;
 }

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -20,6 +20,11 @@
         <div class="kiln-toolbar-inner">
           <button class="user-icon">{% include 'public/media/components/clay-kiln/user-icon.svg' %}</button>
           <div class="flex-span"></div>
+          <button class="kiln-toolbar-button components">
+            <div class="button-flex-inner">{# we need this because firefox cannot make buttons display: flex #}
+              <span class="icon">{% include 'public/media/components/clay-kiln/component-finder.svg' %}</span>
+            </div>
+          </button>
           <button class="kiln-toolbar-button new">
             <div class="button-flex-inner">{# we need this because firefox cannot make buttons display: flex #}
               <span class="icon">{% include 'public/media/components/clay-kiln/new-page.svg' %}</span>


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/DQJogUG9/20-component-finder-mvp)
* allows you to select any (visible) component on the page
* scrolls to the selected component
* list displays the currently selected component when opened

Plus some changes to filterable list:

* `.active` is now `.selected`, since the former is used when clicking/keydown-ing an item
* `click`, `remove`, `settings`, and `reorder` now get the item element as an argument
* rearranged item padding so you can `click` the whole item area

![screen shot 2016-08-17 at 2 00 31 pm](https://cloud.githubusercontent.com/assets/447522/17747498/040ae6fe-6483-11e6-83f5-19d4b1620c11.png)
