### PR TITLE
put components button on the left

### DIFF
--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -46,6 +46,11 @@ body {
   border-left: 1px solid $black-50;
 }
 
+.kiln-toolbar-inner .kiln-toolbar-button-left {
+  border-left: none;
+  border-right: 1px solid $black-50;
+}
+
 .kiln-toolbar-inner .button-flex-inner {
   align-items: center;
   display: flex;

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -19,12 +19,12 @@
         data-components="{{ _components }}">
         <div class="kiln-toolbar-inner">
           <button class="user-icon">{% include 'public/media/components/clay-kiln/user-icon.svg' %}</button>
-          <div class="flex-span"></div>
-          <button class="kiln-toolbar-button components">
+          <button class="kiln-toolbar-button kiln-toolbar-button-left components">
             <div class="button-flex-inner">{# we need this because firefox cannot make buttons display: flex #}
               <span class="icon">{% include 'public/media/components/clay-kiln/component-finder.svg' %}</span>
             </div>
           </button>
+          <div class="flex-span"></div>
           <button class="kiln-toolbar-button new">
             <div class="button-flex-inner">{# we need this because firefox cannot make buttons display: flex #}
               <span class="icon">{% include 'public/media/components/clay-kiln/new-page.svg' %}</span>


### PR DESCRIPTION
this is a temporary measure so that we don't interrupt the muscle memory of users who want to create new pages. it'll be updated when we redesign the toolbar.

![screen shot 2016-08-18 at 10 50 16 am](https://cloud.githubusercontent.com/assets/447522/17778298/955136c8-6531-11e6-992c-79113f3e0e51.png)
