### PR TITLE
Color standards

### DIFF
--- a/behaviors/simple-list-primary.scss
+++ b/behaviors/simple-list-primary.scss
@@ -14,11 +14,11 @@
 }
 
 .simple-list-item.primary {
-  border: 2px solid $green;
+  border: 2px solid $published;
 
   .badge {
     background-color: $white;
-    border: 2px solid $green;
+    border: 2px solid $published;
     border-radius: 10px;
     display: block;
     font-size: 9px;

--- a/behaviors/wysiwyg.scss
+++ b/behaviors/wysiwyg.scss
@@ -167,7 +167,7 @@ $wysiwyg-dropshadow: 0 0 6px $input-shadow;
   }
 
   .medium-editor-toolbar-save {
-    color: $green;
+    color: $published;
     font-size: 18px;
     margin: 0 5px;
   }

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -1,3 +1,18 @@
+// Publish state
+$draft: #d6c8a0;
+$scheduled: #d39d22;
+$published: #149524;
+
+// Toolbar - View Mode
+$toolbar-view: #585c60;
+$toolbar-view-border: #666a6d;
+
+// Toolbar - Edit Mode
+$toolbar-edit: #999c9e;
+$toolbar-edit-border: #b7b9ba;
+
+
+
 // blue - used for page-specific components
 $blue-10: #f6fdff;
 $blue-25: #C5E0E9;

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -19,20 +19,6 @@ $blue-75: #51A2BF;
 $blue-100: #1782A9;
 $blue: $blue-100;
 
-// brown - used for drafts and saving
-$brown-10: #ffb687;
-$brown-25: #e9a77b;
-$brown-50: #d69971;
-$brown-75: #b98462;
-$brown-100: #a17355;
-$brown: $brown-100;
-
-// orange - used for scheduling
-$orange-50: #f0bd5f;
-$orange-75: #efa72f;
-$orange-100: #cc8e28;
-$orange: $orange-100;
-
 // purple - used for layout-specific components
 $purple-10: #fbf3ff;
 $purple-25: #e1cfec;
@@ -48,14 +34,6 @@ $red-50: #EE978D;
 $red-75: #E66355;
 $red-100: #DD2F1C;
 $red: $red-100;
-
-// green - used for publishing
-$green-10: #E7F4E9;
-$green-25: #C4E4C8;
-$green-50: #89CA91;
-$green-75: #4FB05B;
-$green-100: #149524;
-$green: $green-100;
 
 // monochrome - general layout elements and typography
 $white: #fff; // note - we may make this slightly darker at some point

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -5,13 +5,11 @@ $published: #149524;
 
 // Toolbar - View Mode
 $toolbar-view: #585c60;
-$toolbar-view-border: #666a6d;
+$toolbar-view-border: #898c8f;
 
 // Toolbar - Edit Mode
 $toolbar-edit: #999c9e;
 $toolbar-edit-border: #b7b9ba;
-
-
 
 // blue - used for page-specific components
 $blue-10: #f6fdff;

--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -52,7 +52,7 @@
 }
 
 .editor .save {
-  @include button-outlined($brown);
+  @include button-outlined($draft);
 
   flex: 0 0 auto;
   margin-left: 30px;

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -139,7 +139,7 @@ $toolbar-height: 48px;
     }
 
     &.warnings svg {
-      fill: $published;
+      fill: $scheduled;
     }
 
     &.errors svg {
@@ -335,7 +335,7 @@ $schedule-item-width: calc(50% - 8px);
 }
 
 .kiln-toolbar-pane .schedule-publish {
-  @include button-outlined($published, $white);
+  @include button-outlined($scheduled, $white);
   @include full-width();
 
   margin-top: 20px;
@@ -396,13 +396,13 @@ $schedule-item-width: calc(50% - 8px);
 
 // special color for warnings
 .kiln-toolbar-pane .publish-warning .label {
-  color: $published;
+  color: $scheduled;
 }
 
 .kiln-toolbar-pane .warning-message {
   @include primary-text();
 
-  color: $published;
+  color: $scheduled;
   padding: 0 0 20px;
 }
 

--- a/styleguide/pane.scss
+++ b/styleguide/pane.scss
@@ -135,11 +135,11 @@ $toolbar-height: 48px;
     }
 
     &.valid svg {
-      fill: $green;
+      fill: $published;
     }
 
     &.warnings svg {
-      fill: $orange;
+      fill: $published;
     }
 
     &.errors svg {
@@ -282,7 +282,7 @@ $toolbar-height: 48px;
 }
 
 .kiln-toolbar-pane .publish-now {
-  @include button-outlined($green, $white);
+  @include button-outlined($published, $white);
   @include full-width();
 }
 
@@ -335,7 +335,7 @@ $schedule-item-width: calc(50% - 8px);
 }
 
 .kiln-toolbar-pane .schedule-publish {
-  @include button-outlined($orange, $white);
+  @include button-outlined($published, $white);
   @include full-width();
 
   margin-top: 20px;
@@ -354,13 +354,13 @@ $schedule-item-width: calc(50% - 8px);
 
 .publish-valid-icon svg {
   display: inline-block;
-  fill: $green;
+  fill: $published;
   height: 24px;
   width: 24px;
 }
 
 .publish-valid-message {
-  color: $green;
+  color: $published;
   margin: 4px 0; // vertically center with the icon (24px - 16px)
 }
 
@@ -396,13 +396,13 @@ $schedule-item-width: calc(50% - 8px);
 
 // special color for warnings
 .kiln-toolbar-pane .publish-warning .label {
-  color: $orange;
+  color: $published;
 }
 
 .kiln-toolbar-pane .warning-message {
   @include primary-text();
 
-  color: $orange;
+  color: $published;
   padding: 0 0 20px;
 }
 

--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -148,7 +148,7 @@ body {
 }
 
 .kiln-toolbar-inner .scheduled {
-  @include button-filled-large($published);
+  @include button-filled-large($scheduled);
 
   border-left: none;
 

--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -14,7 +14,7 @@ $height: 48px;
 }
 
 .kiln-toolbar {
-  background-color: $black-60;
+  background-color: $toolbar-view;
   height: $height;
   left: 0;
   position: absolute;
@@ -40,15 +40,15 @@ body {
 }
 
 .kiln-toolbar-inner .kiln-toolbar-button, {
-  @include button-filled-large($black-60);
+  @include button-filled-large($toolbar-view);
 
   flex: 0 0 auto;
-  border-left: 1px solid $black-50;
+  border-left: 1px solid $toolbar-view-border;
 }
 
 .kiln-toolbar-inner .kiln-toolbar-button-left {
   border-left: none;
-  border-right: 1px solid $black-50;
+  border-right: 1px solid $toolbar-view-border;
 }
 
 .kiln-toolbar-inner .button-flex-inner {

--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -119,7 +119,7 @@ body {
 }
 
 .kiln-toolbar-inner .draft {
-  @include button-filled-large($brown);
+  @include button-filled-large($draft);
 
   border-left: none;
 
@@ -133,7 +133,7 @@ body {
 }
 
 .kiln-toolbar-inner .published {
-  @include button-filled-large($green);
+  @include button-filled-large($published);
 
   border-left: none;
 
@@ -148,7 +148,7 @@ body {
 }
 
 .kiln-toolbar-inner .scheduled {
-  @include button-filled-large($orange);
+  @include button-filled-large($published);
 
   border-left: none;
 


### PR DESCRIPTION
- Added new semantic colors
- Replaced brown, orange, green with semantic draft, scheduled, published colors
- delete unused brown, orange, green colors
- semantic toolbar view colors applied to toolbar

<img width="227" alt="screen shot 2016-08-19 at 1 29 48 pm" src="https://cloud.githubusercontent.com/assets/97846/17818312/0b9c9702-6611-11e6-96c0-e23d3c108941.png">