### PR TITLE
border on top of toolbar to visually separate it from content

### DIFF
--- a/styleguide/toolbar.scss
+++ b/styleguide/toolbar.scss
@@ -15,6 +15,7 @@ $height: 48px;
 
 .kiln-toolbar {
   background-color: $toolbar-view;
+  border-top: 1px solid $toolbar-view-border;
   height: $height;
   left: 0;
   position: absolute;


### PR DESCRIPTION
Before:
![Before](https://cloud.githubusercontent.com/assets/97846/17819021/0f38cbd0-6614-11e6-8923-43eed29bea48.png)

After:
![After](https://cloud.githubusercontent.com/assets/97846/17819024/122ec4f2-6614-11e6-93c1-714d91a46bc6.png)