### PR TITLE
Component Search Close Pane On Selection

### DIFF
--- a/services/pane/components.js
+++ b/services/pane/components.js
@@ -56,6 +56,7 @@ function openComponents(path) {
         select.select(component);
         select.scrollToComponent(component);
         el.classList.add('selected');
+        pane.close(); // Close the pane so user can interact with component
       },
       inputPlaceholder: 'Search all visible components'
     }),


### PR DESCRIPTION
Like the title says, just closes the pane when a component is selected so a user can interact with it immediately.