### PR TITLE
Fix: Add component sometimes closing tabs

### DIFF
--- a/services/pane/add-component.js
+++ b/services/pane/add-component.js
@@ -14,7 +14,7 @@ function openAddComponent(components, options) {
     innerEl = filterableList.create(components, {
       click: function (id) {
         return addComponent(options.pane, options.field, id, options.ref)
-          .then(() => close()); // only close pane if we added successfully
+          .then(() => pane.close()); // only close pane if we added successfully
       }
     });
 


### PR DESCRIPTION
Updated to call `pane.close()` instead of `window.close()` which might close a browser tab.