### PR TITLE
add deadzone

### DIFF
--- a/controllers/filterable-list.js
+++ b/controllers/filterable-list.js
@@ -87,7 +87,7 @@ function getIndex(el, container) {
 function addDragula(el, reorder) {
   var dropAreaClass = 'dragula-drop-area',
     dragItemClass = 'dragula-list-item',
-    drag = dragula([el]),
+    drag = dragula([el], { deadzone: 10 }),
     oldIndex;
 
   drag.on('drag', function (selectedItem, container) {

--- a/decorators/component-list.js
+++ b/decorators/component-list.js
@@ -75,6 +75,7 @@ function addDragula(el, options) {
     dragItemClass = 'dragula-item',
     dragItemUnsavedClass = 'dragula-not-saved',
     drag = dragula([el], {
+      deadzone: 10,
       ignoreInputTextSelection: true, // allow selecting text in draggable components
       moves: function (selectedItem, container, handle) {
         // only allow direct child components of a list to be dragged

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "coveralls": "^2.11.2",
     "dollar-slice": "^2.1.0",
     "domify": "^1.3.3",
-    "dragula": "^3.5.4",
+    "dragula": "gitterHQ/dragula#feature/deadzone",
     "eslint": "^3.2.2",
     "eventify": "^2.0.0",
     "flatpickr": "^1.9.1",


### PR DESCRIPTION
pull dragula from Gitter's fork, until [this PR](https://github.com/bevacqua/dragula/pull/379) is merged and released. This adds a 10px deadzone to all dragdrops in kiln, hopefully eliminating any accidental drags when clicking into components and list items.