### PR TITLE
fixed schedule form in firefox

### DIFF
--- a/styleguide/datepicker.scss
+++ b/styleguide/datepicker.scss
@@ -3,12 +3,22 @@
 @import 'colors';
 @import '~flatpickr/dist/flatpickr.min.css';
 
+.flatpickr-wrapper.static {
+  display: block; // always show the inputs
+}
+
 .flatpickr-wrapper.inline .flatpickr-calendar,
 .flatpickr-wrapper.open .flatpickr-calendar {
   @include datepicker-layer();
 
   // not the full kiln-copy (no sizes, overrides, etc)
   font-family: $system-fonts;
+}
+
+// right align the time picker, preventing overflow to the right of the pane
+.schedule-input[type='time'] + .flatpickr-calendar {
+  left: auto;
+  right: 0;
 }
 
 .flatpickr-month {


### PR DESCRIPTION
this fixes the schedule form in firefox, and right-aligns the time picker so it flows correctly.

![screen shot 2016-09-13 at 10 54 27 am](https://cloud.githubusercontent.com/assets/447522/18478799/89a97654-79a0-11e6-92ea-06e5838731a1.png)
