### PR TITLE
convert all headers to strong tags

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -14,6 +14,17 @@ var _ = require('lodash'),
   site = require('../services/site'),
   refAttr = references.referenceAttribute;
 
+// pass config actions to text-model
+model.updateSameAs({
+  // all headings should be converted to bold text
+  H1: 'STRONG',
+  H2: 'STRONG',
+  H3: 'STRONG',
+  H4: 'STRONG',
+  H5: 'STRONG',
+  H6: 'STRONG'
+});
+
 /**
  * whan that sellection, with his ranges soote
  * the finalle node hath perced to the roote

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "speakingurl": "^9.0.0",
     "striptags": "^2.1.1",
     "style-loader": "^0.13.1",
-    "text-model": "^0.2.1",
+    "text-model": "^0.3.0",
     "webpack": "^1.13.2",
     "whatwg-fetch": "^1.0.0"
   }


### PR DESCRIPTION
we had some issues with people accidentally pasting in headers into paragraphs, which totally breaks the editing experience (since `<h2>` tags cannot live inside `<p>` tags). This converts any pasted in header to bold text, rather than simply preventing the paste.