### PR TITLE
Filtered List Item Title Width Bug

### DIFF
--- a/styleguide/filterable-list.scss
+++ b/styleguide/filterable-list.scss
@@ -68,7 +68,7 @@
 .dragula-list-item .filtered-item-title {
   @include primary-text();
 
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   padding: 15px 0;
 }
 


### PR DESCRIPTION
![screen shot 2016-09-13 at 1 54 28 pm](https://cloud.githubusercontent.com/assets/4906712/18485220/f35c00b2-79b9-11e6-855d-75ecb8f6c19c.png)


Small issue where the content of a filtered list item title grows past the width of the pane based on its content. The `flex-shrink` needs to be set to `1` so that it doesn't grow too wide, and since no other items in the flexed container have a `flex-grow` of `1` or more, the title will always grow to fill the space.