### PR TITLE
Expose Behavior Add Function In Services

### DIFF
--- a/services/forms/behaviors.js
+++ b/services/forms/behaviors.js
@@ -101,3 +101,4 @@ function run(context) {
 exports.add = add;
 exports.run = run;
 exports.getExpandedBehaviors = getExpandedBehaviors;
+_.set(window, 'kiln.services.register-behavior', module.exports.add); // export for plugins


### PR DESCRIPTION
**Purpose:** Allow behaviors to be registered through Kiln's normal behavior add process

**Advantage:** Makes it so arguments can be passed to custom behaviors. 