### PR TITLE
new selectors

### DIFF
--- a/client.js
+++ b/client.js
@@ -7,6 +7,9 @@ var nodeUrl = require('url'),
   dom = require('@nymag/dom'),
   EditorToolbar = require('./controllers/kiln-toolbar'),
   render = require('./services/components/render'),
+  keyCode = require('keycode'),
+  select = require('./services/components/select'),
+  focus = require('./decorators/focus'),
   progress = require('./services/progress'),
   Konami = require('konami-js'),
   takeOffEveryZig = require('./services/pane/move-zig'),
@@ -84,3 +87,20 @@ window.addEventListener('offline', function () {
 });
 
 new Konami(takeOffEveryZig);
+
+// navigate components when hitting ↑ / ↓ arrows (if there's a component selected)
+document.addEventListener('keydown', function (e) {
+  const current = select.getCurrentSelected();
+
+  if (current && !focus.hasCurrentFocus()) {
+    let key = keyCode(e);
+
+    if (key === 'up') {
+      e.preventDefault();
+      return select.navigateComponents(current, 'prev')(e);
+    } else if (key === 'down') {
+      e.preventDefault();
+      return select.navigateComponents(current, 'next')(e);
+    }
+  }
+});

--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -1,6 +1,8 @@
 const dom = require('@nymag/dom'),
+  keyCode = require('keycode'),
   events = require('../services/events'),
   focus = require('../decorators/focus'),
+  select = require('../services/components/select'),
   state = require('../services/page-state'),
   progress = require('../services/progress'),
   rules = require('../validators'),
@@ -53,13 +55,14 @@ EditorToolbar = function (el) {
     }
   });
 
-  // close ANY open forms if user hits ESC
+  // when the user hits ESC,
+  // if a form is open, close it
+  // else if a component is selected, unselect it (don't close form AND unselect)
   document.addEventListener('keydown', function (e) {
-    if (e.keyCode === 27) {
-      focus.unfocus();
-      // note: this will work even if there isn't a current form open
-      // fun fact: it'll unselect components as well, in case the user has a form closed
-      // but a component selected, and they don't want that
+    var key = keyCode(e);
+
+    if (key === 'esc') {
+      return focus.hasCurrentFocus() ? focus.unfocus() : select.unselect();
     }
   });
 

--- a/decorators/focus.js
+++ b/decorators/focus.js
@@ -74,7 +74,6 @@ function hasCurrentFocus() {
  */
 function unfocus() {
   if (forms.isFormValid()) {
-    select.unselect();
     currentFocus = null;
     return forms.close();
   } else {

--- a/media/down.svg
+++ b/media/down.svg
@@ -1,0 +1,1 @@
+<svg width="18" height="12" viewBox="0 0 18 12" xmlns="http://www.w3.org/2000/svg"><path d="M9 11.115l-9-9L2.115 0 9 6.87 15.885 0 18 2.115z" fill="#727272" fill-rule="evenodd"/></svg>

--- a/media/parent.svg
+++ b/media/parent.svg
@@ -1,1 +1,0 @@
-<svg width="18" height="16" viewBox="0 0 18 16" xmlns="http://www.w3.org/2000/svg"><path fill="#727272" d="M12.706 6.353l-1.504 1.503-3.79-3.8v9.709H18v2.117H5.294V4.055l-3.79 3.801L0 6.353 6.353 0z" fill-rule="evenodd"/></svg>

--- a/media/up.svg
+++ b/media/up.svg
@@ -1,0 +1,1 @@
+<svg width="18" height="12" viewBox="0 0 18 12" xmlns="http://www.w3.org/2000/svg"><path d="M9 0L0 9l2.115 2.115L9 4.245l6.885 6.87L18 9z" fill="#727272" fill-rule="evenodd"/></svg>

--- a/services/components/add-component.js
+++ b/services/components/add-component.js
@@ -144,7 +144,6 @@ function addComponent(pane, field, name, prevRef) {
         } else {
           return render.addComponentsHandlers(newEl).then(function () {
             focus.unfocus();
-            select.unselect();
             progress.done();
             return select.select(newEl);
           });

--- a/services/components/select.js
+++ b/services/components/select.js
@@ -110,6 +110,9 @@ function removePadding() {
 function select(el) {
   var component = getComponentEl(el);
 
+  // only one component can be selected at a time
+  unselect();
+
   // selected component gets .selected, parent gets .selected-parent
   if (component && component.tagName !== 'HTML') {
     component.classList.add('selected');
@@ -124,7 +127,7 @@ function select(el) {
  * remove selection
  */
 function unselect() {
-  var current = currentSelected || dom.find('.selected');
+  var current = currentSelected || dom.find('.component-selector-wrapper.selected');
 
   if (current) {
     current.classList.remove('selected');
@@ -157,7 +160,6 @@ function componentClickHandler(el, e) {
     e.stopSelection = true;
 
     if (!el.classList.contains('selected')) {
-      unselect();
       select(el);
     }
   }
@@ -377,7 +379,6 @@ function navigateComponents(el, direction) {
 
     if (component) {
       return focus.unfocus().then(function () {
-        unselect();
         select(component);
         scrollToComponent(component);
       }).catch(_.noop);

--- a/services/components/select.js
+++ b/services/components/select.js
@@ -62,50 +62,28 @@ function getParentField(componentEl, parentSchema, property) {
  * @param {MouseEvent} e
  */
 function select(el) {
-  var component = getComponentEl(el),
-    parent = getParentEl(component);
+  var component = getComponentEl(el);
 
   // selected component gets .selected, parent gets .selected-parent
   if (component) {
     component.classList.add('selected');
     currentSelected = component;
   }
-  if (parent) {
-    parent.classList.add('selected-parent');
-  }
-  window.kiln.trigger('select', component);
-}
 
-/**
- * remove selected classes on current and parent component
- * @param {Element} [el]
- * @param {Element} [parent]
- */
-function removeClasses(el, parent) {
-  if (el) {
-    el.classList.remove('selected');
-  }
-  if (parent) {
-    parent.classList.remove('selected-parent');
-  }
+  window.kiln.trigger('select', component);
 }
 
 /**
  * remove selection
  */
 function unselect() {
-  var current, parent;
+  var current = currentSelected || dom.find('.selected');
 
-  if (currentSelected) {
-    current = currentSelected;
-    parent = dom.closest(currentSelected.parentNode, '[' + references.referenceAttribute + ']');
-  } else {
-    current = dom.find('.selected');
-    parent = dom.find('.selected-parent');
+  if (current) {
+    current.classList.remove('selected');
+    window.kiln.trigger('unselect', current);
   }
 
-  removeClasses(current, parent);
-  window.kiln.trigger('unselect', current);
   currentSelected = null;
 }
 
@@ -230,29 +208,6 @@ function addLabel(selector, name) {
 }
 
 /**
- * add parent arrow and handler if parent exists
- * @param {Element} selector
- * @param {object} parent
- */
-function addParentHandler(selector, parent) {
-  var button = dom.find(selector, '.selected-info-parent');
-
-  if (parent.el) {
-    // if parent exists at all, add the handler
-    button.classList.remove(hidden);
-    button.addEventListener('click', function (e) {
-      e.stopPropagation();
-      // Select the parent.
-      return focus.unfocus().then(function () {
-        unselect();
-        select(parent.el);
-        scrollToComponent(parent.el);
-      }).catch(_.noop);
-    });
-  }
-}
-
-/**
  * determine if a component has settings
  * @param {object} options
  * @returns {boolean}
@@ -325,17 +280,6 @@ function addDeleteHandler(selector, parent, el, options) {
 }
 
 /**
- * unhide bottom menu if add component is available
- * @param {Element} selector
- * @param {object} parent
- */
-function unhideBottomMenu(selector, parent) {
-  if (parent.isComponentList || parent.isComponentProp) {
-    dom.find(selector, '.component-selector-bottom').classList.remove(hidden);
-  }
-}
-
-/**
  * unhide and add handler for add component (to list)
  * @param {Element} selector
  * @param {object} parent
@@ -400,17 +344,12 @@ function handler(el, options) {
     // add options to the component selector
     // set component label
     addLabel(selector, name);
-    // if parent, unhide + add handler
-    addParentHandler(selector, parent);
 
     // if settings, unhide + add handler
     addSettingsHandler(selector, options);
     // if delete, unhide + add handler
     addDeleteHandler(selector, parent, el, options);
 
-    // if component lives in a list or property, unhide bottom
-    // note: more options might exist in the bottom menu in the future
-    unhideBottomMenu(selector, parent);
     // if list, unhide + add handler
     addAddHandler(selector, parent, options);
     // if property, unhide + add handler

--- a/services/components/select.test.js
+++ b/services/components/select.test.js
@@ -1,3 +1,4 @@
+/* eslint max-nested-callbacks: [1, 5] */
 var dirname = __dirname.split('/').pop(),
   filename = __filename.split('/').pop().split('.').shift(),
   references = require('../references'),
@@ -48,42 +49,11 @@ describe(dirname, function () {
         expect(component.classList.contains('selected')).to.equal(true);
       });
 
-      it('adds .selected-parent class when parent component exists', function () {
-        var el = stubEditableElement(),
-          component = stubComponent(),
-          parent = stubComponent();
-
-        parent.appendChild(component);
-        component.appendChild(el);
-
-        fn(el);
-        expect(parent.classList.contains('selected-parent')).to.equal(true);
-      });
-
       it('adds .selected class when element is component', function () {
         var el = stubEditableComponent();
 
         fn(el);
         expect(el.classList.contains('selected')).to.equal(true);
-      });
-
-      it('adds .selected-parent class when parent component exists and elemnent is component', function () {
-        var el = stubEditableComponent(),
-          parent = stubComponent();
-
-        parent.appendChild(el);
-
-        fn(el);
-        expect(parent.classList.contains('selected-parent')).to.equal(true);
-      });
-
-      it('throws error if element is not inside a component', function () {
-        var el = stubEditableElement(),
-          result = function () {
-            return fn(el);
-          };
-
-        expect(result).to.throw(Error);
       });
     });
 
@@ -156,64 +126,6 @@ describe(dirname, function () {
         sandbox.stub(edit, 'getSchema').returns(Promise.resolve({}));
         return fn(el, options).then(function (res) {
           expect(res.querySelector('.component-selector .selected-label').textContent).to.equal('Fake Name');
-        });
-      });
-
-      it('adds the parent label if the component has a parent', function () {
-        var el = stubComponent(),
-          parent = stubComponent(),
-          options = {ref: 'fakeRef', data: {}, path: 'fakePath'};
-
-        // Setup: Create a parent component and selected child component.
-        el.setAttribute(references.referenceAttribute, options.ref);
-        parent.setAttribute(references.referenceAttribute, 'parentRef');
-        parent.appendChild(el);
-        sandbox.stub(references, 'getComponentNameFromReference').returns('fakeName');
-        sandbox.stub(focus, 'unfocus').returns(Promise.resolve());
-        sandbox.stub(edit, 'getSchema').returns(Promise.resolve({}));
-        return fn(el, options).then(function (res) {
-          expect(res.querySelector('.component-selector .selected-info-parent').classList.contains(hidden)).to.equal(false); // parent label was added
-        });
-      });
-
-      it('does not add the parent label if component does not have parent', function () {
-        var el = stubComponent(),
-          options = {ref: 'fakeRef', data: {}, path: 'fakePath'};
-
-        sandbox.stub(references, 'getComponentNameFromReference').returns('fake-name');
-        sandbox.stub(edit, 'getSchema').returns(Promise.resolve({}));
-        return fn(el, options).then(function (res) {
-          expect(res.querySelector('.component-selector .selected-info-parent').classList.contains(hidden)).to.equal(true);
-        });
-      });
-
-      it('will select the parent component if parent label in the component selector is clicked', function (done) {
-        var el = stubComponent(),
-          parent = stubComponent(),
-          options = {ref: 'fakeRef', data: {}, path: 'fakePath'};
-
-        // Setup: Create a parent component and selected child component.
-        el.setAttribute(references.referenceAttribute, options.ref);
-        parent.setAttribute(references.referenceAttribute, 'parentRef');
-        parent.appendChild(el);
-        sandbox.stub(references, 'getComponentNameFromReference').returns('fakeName');
-        sandbox.stub(focus, 'unfocus').returns(Promise.resolve());
-        sandbox.stub(edit, 'getSchema').returns(Promise.resolve({}));
-
-        function expectSelected() {
-          expect(parent.classList.contains('selected')).to.equal(true); // Parent is selected.
-          expect(el.classList.contains('selected')).to.equal(false); // Child is not selected.
-          done();
-        }
-
-        fn(el, options).then(function () {
-          expect(parent.classList.contains('selected')).to.equal(false); // Parent is not selected.
-
-          // Trigger click on parent label in the component's bar.
-          el.querySelector('.component-selector .selected-info-parent').dispatchEvent(new Event('click'));
-
-          // wait for repaint before checking
-          setTimeout(expectSelected, 0);
         });
       });
 

--- a/services/components/visible-components.js
+++ b/services/components/visible-components.js
@@ -1,0 +1,48 @@
+const _ = require('lodash'),
+  dom = require('@nymag/dom'),
+  references = require('../references');
+
+/**
+ * determine if an element is visible on the page
+ * @param {Element} el
+ * @returns {boolean}
+ */
+function showVisible(el) {
+  // checking offsetParent works for all non-fixed elements,
+  // and is much faster than checking getComputedStyle(el).display and visibility
+  return el.offsetParent !== null;
+}
+
+/**
+ * generate a list of components that includes all visible components on the page
+ * @returns {array} array of elements
+ */
+function list() {
+  return _.filter(dom.findAll(`[${references.referenceAttribute}]`), showVisible);
+}
+
+/**
+ * get previous visible component on the page
+ * @param {Element} el of current component
+ * @returns {Element|undefined}
+ */
+function getPrev(el) {
+  const currentList = list(); // get a fresh list
+
+  return currentList[currentList.indexOf(el) - 1];
+}
+
+/**
+ * get next visible component on the page
+ * @param {Element} el of current component
+ * @returns {Element|undefined}
+ */
+function getNext(el) {
+  const currentList = list(); // get a fresh list
+
+  return currentList[currentList.indexOf(el) + 1];
+}
+
+module.exports.list = list; // note: don't memoize, as people add/remove components frequently
+module.exports.getPrev = getPrev;
+module.exports.getNext = getNext;

--- a/services/components/visible-components.js
+++ b/services/components/visible-components.js
@@ -10,7 +10,10 @@ const _ = require('lodash'),
 function showVisible(el) {
   // checking offsetParent works for all non-fixed elements,
   // and is much faster than checking getComputedStyle(el).display and visibility
-  return el.offsetParent !== null;
+  // note: [data-kiln-hidden] is a special attribute you can add to your
+  // component's root element to hide it from the visible component list
+  // and selector-based component navigation
+  return el.offsetParent !== null && !el.getAttribute('data-kiln-hidden');
 }
 
 /**

--- a/services/pane/components.js
+++ b/services/pane/components.js
@@ -42,7 +42,6 @@ function openComponents(path) {
           currentSelectedItem.classList.remove('selected');
         }
 
-        select.unselect();
         select.select(component);
         select.scrollToComponent(component);
         el.classList.add('selected');

--- a/services/pane/components.js
+++ b/services/pane/components.js
@@ -4,21 +4,11 @@ const _ = require('lodash'),
   references = require('../references'),
   select = require('../components/select'),
   label = require('../label'),
+  visibleComponents = require('../components/visible-components'),
   invisibleList = require('../components/invisible-list'),
   head = require('../components/head-components'),
   promises = require('../promises'),
   pane = require('./');
-
-/**
- * determine if an element is visible on the page
- * @param {Element} el
- * @returns {boolean}
- */
-function showVisible(el) {
-  // checking offsetParent works for all non-fixed elements,
-  // and is much faster than checking getComputedStyle(el).display and visibility
-  return el.offsetParent !== null;
-}
 
 /**
  * get name of component from the component's element
@@ -41,9 +31,9 @@ function getName(el) {
  */
 function openComponents(path) {
   var searchHeader = 'Find Component',
-    visibleComponents = _.filter(dom.findAll(`[${references.referenceAttribute}]`), showVisible).map(getName),
     currentSelected = dom.find('.component-selector-wrapper.selected'),
-    searchContent = filterableList.create(visibleComponents, {
+    visibleList = visibleComponents.list().map(getName),
+    searchContent = filterableList.create(visibleList, {
       click: function (id, el) {
         var currentSelectedItem = dom.find('.filtered-item.selected'),
           component = dom.find(`[${references.referenceAttribute}="${id}"]`);

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -13,9 +13,11 @@ $toolbar-edit-border: #b7b9ba;
 
 // selector borders
 // note: other greys will be phased out in favor of semantic grey colors
-$selector-border: #9b9b9b;
-$selector-icon: #727272;
-$selector-bg: rgba(255, 255, 255, .95);
+$selector-border: #727272;
+$selector-icon: $selector-border;
+$selector-text: $selector-border;
+$selector-bg: rgba(255, 255, 255, .95); // background of selector menus
+$selector-overlay: rgba(255, 255, 255, .8); // fade other components
 
 // placeholder colors
 $placeholder-label: $selector-icon;

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -3,56 +3,67 @@
 @import 'layers';
 @import 'buttons';
 
-// selector offsets, for the selector outline
-$offset-width: 16px;
-$offset-width-half: $offset-width / 2;
-$offset-height: 16px;
-$offset-height-half: $offset-height / 2;
-$parent-offset: 8px; // how much wider should parent outline be (each side)
-
-// icon sizes
-$action-icon-small: 18px;
-
-// page-specific
-$page-color: $blue;
-$page-bg-color: $blue-50;
-$page-parent-color: $blue-75;
-$page-parent-bg-color: $blue-25;
-
-// layout-specific
-$layout-color: $purple;
-$layout-bg-color: $purple-50;
-$layout-parent-color: $purple-75;
-$layout-parent-bg-color: $purple-25;
+// positioning - how much wider/taller should selectors be than components?
+$selector-offset: 16px;
+// amount of padding between component edges and selector border
+$half-selector-offset: $selector-offset / 2;
+$icon-size: 18px;
+$menu-size: 48px;
+$selector-fade-time: 150ms;
+$selector-fade-easing: linear;
 
 // component element needs to be position: relative for the selectors to display
 .component-selector-wrapper {
+  padding: $half-selector-offset;
   position: relative;
+}
+
+.component-selector-wrapper.selected {
+  padding: $half-selector-offset;
+}
+
+// fade things behind the component
+.component-selector-wrapper:before {
+  animation: prevent-flash 200ms linear 200ms forwards;
+  background: $selector-overlay;
+  content: '';
+  height: 100vh;
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  transition: opacity $selector-fade-time $selector-fade-easing;
+  top: 0;
+  visibility: hidden;
+  width: 100vw;
+  z-index: -1;
+}
+
+// these overlays need to be visible so they can animate, but will flash
+// the screen if they're visible when the page loads. this sets them to
+// be hidden for the first 400ms, then make themselves visible
+@keyframes prevent-flash {
+  0% { visibility: hidden; }
+  100% { visibility: visible; }
+}
+
+.component-selector-wrapper.selected:before {
+  opacity: 1;
 }
 
 // selector outlines
 .component-selector {
-  border-style: solid;
-  border-width: 1px;
-  // selector colors are set for the selected component by default,
-  // then overridden for the selected-parent. this is so we don't get a
-  // visual jump when animating them in
-  // (technically the parent DOES jump, but it's a lot less noticible than the
-  // selected component. plus, the colors are similar enough that you don't see it)
-  border-color: $selector-border;
-  // subtle shadow to create more visual distinction between selectors and the
-  // stuff behind them
-  box-shadow: 1px 1px 20px -11px $black;
-  height: calc(100% + #{$offset-height});
-  left: -$offset-width-half;
+  border: 1px solid $selector-border;
+  height: 100%;
+  left: 0;
   opacity: 0;
   // because we're just setting opacity to show/hide, don't allow child selectors to be clicked
-  // note: selected-parent and selected both set this to `all` so current selectors can be clicked
+  // note: .selected sets this to `all` so current selectors can be clicked
   pointer-events: none;
   position: absolute;
-  top: -$offset-height-half;
-  transition: 50ms opacity linear; // fade out quickly
-  width: calc(100% + #{$offset-width});
+  top: 0;
+  transition: opacity $selector-fade-time $selector-fade-easing;
+  width: 100%;
   z-index: -1; // should be less than any element in the component itself
 }
 
@@ -60,23 +71,18 @@ $layout-parent-bg-color: $purple-25;
 .component-selector-top,
 .component-selector-bottom {
   background: $selector-bg;
-  border-color: transparent;
-  border-width: 1px;
-  border-style: solid;
+  border: 1px solid $selector-border;
+  height: $menu-size;
+  min-width: calc(100% + 2px); // include border on both sides
   right: -1px; // align borders
   position: absolute;
 }
 
-// place the top and bottom menus bisecting the outline vertically
 .component-selector-top {
-  border-color: $selector-border;
   bottom: 100%;
 }
 
-// bottom menu is more offset, since it concerns actions that don't
-// affect the component itself (but rather things around it, e.g. adding new components)
 .component-selector-bottom {
-  border-color: $selector-border;
   top: 100%;
 }
 
@@ -84,63 +90,80 @@ $layout-parent-bg-color: $purple-25;
 .component-selector-top,
 .component-selector-bottom,
 .selected-info,
+.selector-location,
 .selected-actions,
-.component-selector-bottom {
+.selector-navigation {
   align-items: center;
   display: flex;
   flex-flow: row;
   justify-content: flex-start;
 }
 
+// smaller menu areas need to flex
 .selected-info {
-  border-left: 10px solid $layout-color;
-  height: 48px;
+  flex: 1 0 auto;
 }
 
-.kiln-page-area .selected-info {
-  border-left-color: $page-color;
+.selector-location {
+  flex: 0 0 auto;
+  margin-left: 14px;
 }
 
-// current component label
+.selected-actions {
+  flex: 0 0 auto;
+}
+
+.selector-navigation {
+  flex: 1 0 auto;
+}
+
+// component location
+.selector-location svg {
+  fill: $selector-icon;
+  height: 11px;
+  margin: 0;
+  width: 11px;
+
+  * {
+    // fill for paths and groups inside the icons
+    fill: $selector-icon;
+  }
+}
+
+// multi-page / single-page toggle
+.selector-this-page {
+  display: none;
+}
+
+.selector-many-pages {
+  display: flex;
+}
+
+.kiln-page-area .selector-this-page {
+  display: flex;
+}
+
+.kiln-page-area .selector-many-pages {
+  display: none;
+}
+
+// component label
 .selected-label {
   @include label();
 
-  color: $selector-icon;
+  color: $selector-text;
+  flex: 1 0 auto;
   font-size: 14px;
-  line-height: $action-icon-small; // same vertical space as the icons
+  line-height: $icon-size; // same vertical space as the icons
   margin: 0;
+  text-align: left;
   white-space: nowrap;
 }
 
-// selected parent
-.component-selector-wrapper.selected-parent > .component-selector {
-  // include overrides for outline offset (width only)
-  left: -#{$offset-width-half + $parent-offset};
-  width: calc(100% + #{$offset-width + $parent-offset * 2});
-
-  // show selector
-  opacity: 1;
-  pointer-events: all;
-  transition: 250ms opacity ease-out; // fade in slower than the current component
-
-  // override colors
-  .selected-info {
-    border-color: $layout-parent-bg-color;
-  }
-
-  // hide extraneous buttons
-  .selected-info-parent,
-  .selected-action-delete,
-  .component-selector-bottom {
-    display: none;
-  }
-}
-
-.kiln-page-area .component-selector-wrapper.selected-parent > .component-selector {
-  // override colors
-  .selected-info {
-    border-color: $page-parent-bg-color;
-  }
+// bottom add/replace button should have border
+.selected-add,
+.selected-replace {
+  border-left: 1px solid $selector-border;
 }
 
 // selected component
@@ -148,34 +171,20 @@ $layout-parent-bg-color: $purple-25;
   // show selector
   opacity: 1;
   pointer-events: all;
-  transition: 150ms opacity ease-out; // fade relatively quickly
 }
 
 // z-index setting
 // needs to be:
-// 1. selected parent (to appear above other page elements)
-// 2. components inside selected parent (so you can click into them)
-// 3. selected component (to appear above its siblings)
-// 4. components inside selected component (so you can click into them)
-
-.component-selector-wrapper.selected-parent {
-  z-index: 1  !important;
-}
-
-// parent component: siblings of the selected component need a higher z-index
-// than the parent selector, but a lower index than the current selector
-.component-selector-wrapper.selected-parent [data-uri] {
-  z-index: 2;
-}
-
+// 1. selected component (to appear above its siblings)
+// 2. components inside selected component (so you can click into them)
 .component-selector-wrapper.selected {
-  z-index: 3 !important;
+  z-index: 1 !important;
 }
 
 // selected component: components inside the selected component ALSO needs a higher z-index
 // so we can click into them when the parent is selected
 .component-selector-wrapper.selected [data-uri] {
-  z-index: 4;
+  z-index: 2;
 }
 
 // all editable elements should have some kind of ux showing they can be edited

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -6,7 +6,7 @@
 // positioning - how much wider/taller should selectors be than components?
 $selector-offset: 16px;
 // amount of padding between component edges and selector border
-$half-selector-offset: $selector-offset / 2;
+$half-selector-offset: $selector-offset / 2 + 2; // 1px on each side to show border
 $icon-size: 18px;
 $menu-size: 48px;
 $selector-fade-time: 150ms;
@@ -14,12 +14,7 @@ $selector-fade-easing: linear;
 
 // component element needs to be position: relative for the selectors to display
 .component-selector-wrapper {
-  padding: $half-selector-offset;
   position: relative;
-}
-
-.component-selector-wrapper.selected {
-  padding: $half-selector-offset;
 }
 
 // fade things behind the component
@@ -54,16 +49,16 @@ $selector-fade-easing: linear;
 // selector outlines
 .component-selector {
   border: 1px solid $selector-border;
-  height: 100%;
-  left: 0;
+  height: calc(100% + 2px);
+  left: -1px; // to display border around components which might have backgrounds/borders
   opacity: 0;
   // because we're just setting opacity to show/hide, don't allow child selectors to be clicked
   // note: .selected sets this to `all` so current selectors can be clicked
   pointer-events: none;
   position: absolute;
-  top: 0;
+  top: -1px; // to display border around components which might have backgrounds/borders
   transition: opacity $selector-fade-time $selector-fade-easing;
-  width: 100%;
+  width: calc(100% + 2px);
   z-index: -1; // should be less than any element in the component itself
 }
 

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -45,6 +45,8 @@ $selector-fade-easing: linear;
   top: 0;
   transition: opacity $selector-fade-time $selector-fade-easing;
   width: 100%;
+  z-index: -1; // when unselected
+  // so clicking into a component will set caret to proper position for inline forms
 }
 
 // menus

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -6,7 +6,7 @@
 // positioning - how much wider/taller should selectors be than components?
 $selector-offset: 16px;
 // amount of padding between component edges and selector border
-$half-selector-offset: $selector-offset / 2 + 2; // 1px on each side to show border
+$half-selector-offset: $selector-offset / 2;
 $icon-size: 18px;
 $menu-size: 48px;
 $selector-fade-time: 150ms;
@@ -18,8 +18,7 @@ $selector-fade-easing: linear;
 }
 
 // fade things behind the component
-.component-selector-wrapper:before {
-  animation: prevent-flash 200ms linear 200ms forwards;
+.component-selector:before {
   background: $selector-overlay;
   content: '';
   height: 100vh;
@@ -29,56 +28,58 @@ $selector-fade-easing: linear;
   position: fixed;
   transition: opacity $selector-fade-time $selector-fade-easing;
   top: 0;
-  visibility: hidden;
   width: 100vw;
   z-index: -1;
 }
 
-// these overlays need to be visible so they can animate, but will flash
-// the screen if they're visible when the page loads. this sets them to
-// be hidden for the first 400ms, then make themselves visible
-@keyframes prevent-flash {
-  0% { visibility: hidden; }
-  100% { visibility: visible; }
-}
-
-.component-selector-wrapper.selected:before {
-  opacity: 1;
-}
-
 // selector outlines
 .component-selector {
-  border: 1px solid $selector-border;
-  height: calc(100% + 2px);
-  left: -1px; // to display border around components which might have backgrounds/borders
+  height: 100%;
+  left: 0;
   opacity: 0;
   // because we're just setting opacity to show/hide, don't allow child selectors to be clicked
   // note: .selected sets this to `all` so current selectors can be clicked
   pointer-events: none;
   position: absolute;
-  top: -1px; // to display border around components which might have backgrounds/borders
+  top: 0;
   transition: opacity $selector-fade-time $selector-fade-easing;
-  width: calc(100% + 2px);
-  z-index: -1; // should be less than any element in the component itself
+  width: 100%;
 }
 
 // menus
 .component-selector-top,
 .component-selector-bottom {
+  @include component-toolbar-layer();
+
   background: $selector-bg;
   border: 1px solid $selector-border;
   height: $menu-size;
-  min-width: calc(100% + 2px); // include border on both sides
-  right: -1px; // align borders
-  position: absolute;
+  width: 100%;
+  right: 0;
+  position: fixed;
+
+  @media screen and (min-width: 600px) {
+    min-width: 100%;
+    position: absolute;
+    width: auto;
+  }
 }
 
 .component-selector-top {
-  bottom: 100%;
+  top: 0;
+
+  @media screen and (min-width: 600px) {
+    bottom: calc(100% + #{$half-selector-offset});
+    top: auto;
+  }
 }
 
 .component-selector-bottom {
-  top: 100%;
+  top: calc(100% - 96px); // account for toolbar
+
+  @media screen and (min-width: 600px) {
+    top: calc(100% + #{$half-selector-offset});
+  }
 }
 
 // all menus use flex to align their buttons
@@ -166,6 +167,11 @@ $selector-fade-easing: linear;
   // show selector
   opacity: 1;
   pointer-events: all;
+
+  // fade other components
+  &:before {
+    opacity: 1;
+  }
 }
 
 // z-index setting

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -34,6 +34,7 @@ $selector-fade-easing: linear;
 
 // selector outlines
 .component-selector {
+  background: inherit;
   height: 100%;
   left: 0;
   opacity: 0;

--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -77,7 +77,7 @@
 .editor-inline .input-container {
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 8px; // inline needs padding for selector borders
+  padding: 0;
 }
 
 /* labels are containers that refer to inputs, textareas, or whatever else */

--- a/styleguide/form.scss
+++ b/styleguide/form.scss
@@ -77,7 +77,7 @@
 .editor-inline .input-container {
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 0;
+  padding: 8px; // inline needs padding for selector borders
 }
 
 /* labels are containers that refer to inputs, textareas, or whatever else */

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -236,15 +236,22 @@
       <aside class="component-selector">
         <aside class="component-selector-top">
           <div class="selected-info">
+            <span class="selector-location">
+              <span class="selector-this-page" title="This Page">{% include 'public/media/components/clay-kiln/this-page.svg' %}</span>
+              <span class="selector-many-pages" title="Multiple Pages">{% include 'public/media/components/clay-kiln/many-pages.svg' %}</span>
+            </span>
             <span class="selector-button selected-label"></span>
-            <button class="selector-button selected-info-parent kiln-hide" title="Select Parent">{% include 'public/media/components/clay-kiln/parent.svg' %}</button>
           </div>
           <div class="selected-actions">
             <button class="selector-button selected-action-settings kiln-hide" title="Component Settings">{% include 'public/media/components/clay-kiln/settings.svg' %}</button>
             <button class="selector-button selected-action-delete kiln-hide" title="Delete Component">{% include 'public/media/components/clay-kiln/delete.svg' %}</button>
           </div>
         </aside>
-        <aside class="component-selector-bottom kiln-hide">
+        <aside class="component-selector-bottom">
+          <div class="selector-navigation">
+            <button class="selector-button selector-nav-up" title="Previous Visible Component">{% include 'public/media/components/clay-kiln/up.svg' %}</button>
+            <button class="selector-button selector-nav-down" title="Next Visible Component">{% include 'public/media/components/clay-kiln/down.svg' %}</button>
+          </div>
           <button class="selector-button selected-add kiln-hide" title="Add Component">{% include 'public/media/components/clay-kiln/add-icon.svg' %}</button>
           <button class="selector-button selected-replace kiln-hide" title="Replace Component">{% include 'public/media/components/clay-kiln/replace-icon.svg' %}</button>
         </aside>
@@ -265,8 +272,8 @@
         <div class="placeholder-top">
           <span class="placeholder-label"></span>
           <span class="placeholder-location">
-            <span class="placeholder-this-page">{% include 'public/media/components/clay-kiln/this-page.svg' %}<span class="placeholder-location-text"> This Page</span></span>
-            <span class="placeholder-many-pages">{% include 'public/media/components/clay-kiln/many-pages.svg' %}<span class="placeholder-location-text"> Multiple Pages</span></span>
+            <span class="placeholder-this-page" title="This Page">{% include 'public/media/components/clay-kiln/this-page.svg' %}<span class="placeholder-location-text"> This Page</span></span>
+            <span class="placeholder-many-pages" title="Multiple Pages">{% include 'public/media/components/clay-kiln/many-pages.svg' %}<span class="placeholder-location-text"> Multiple Pages</span></span>
           </span>
           <span class="placeholder-required kiln-hide">Required</span>
         </div>

--- a/test/fixtures/tpl.js
+++ b/test/fixtures/tpl.js
@@ -140,19 +140,24 @@ function stubComponentSelectorTemplate() {
   return dom.create(`<aside class="component-selector">
     <aside class="component-selector-top">
       <div class="selected-info">
-        <span class="selected-label"></span>
-        <button class="selected-info-parent kiln-hide" title="Select Parent"></button>
+        <span class="selector-location">
+          <span class="selector-this-page" title="This Page"></span>
+          <span class="selector-many-pages" title="Multiple Pages"></span>
+        </span>
+        <span class="selector-button selected-label"></span>
       </div>
-      <div class="selected-actions kiln-hide">
-        <button class="selected-action-settings kiln-hide" title="Component Settings"></button>
-        <button class="selected-action-delete kiln-hide" title="Delete Component"></button>
+      <div class="selected-actions">
+        <button class="selector-button selected-action-settings kiln-hide" title="Component Settings"></button>
+        <button class="selector-button selected-action-delete kiln-hide" title="Delete Component"></button>
       </div>
     </aside>
-    <aside class="component-selector-bottom kiln-hide">
-      <button class="selected-add kiln-hide" title="Add Component">
-        <span class="add-inner">+</span>
-      </button>
-      <button class="selected-replace kiln-hide">replace</button>
+    <aside class="component-selector-bottom">
+      <div class="selector-navigation">
+        <button class="selector-button selector-nav-up" title="Previous Visible Component"></button>
+        <button class="selector-button selector-nav-down" title="Next Visible Component"></button>
+      </div>
+      <button class="selector-button selected-add kiln-hide" title="Add Component"></button>
+      <button class="selector-button selected-replace kiln-hide" title="Replace Component"></button>
     </aside>
   </aside>`);
 }


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/34apsQdd/47-selectors)
* removed parent button
* added prev/next buttons
* added this page / multiple pages icon
* added ↑/↓ keyboard navigation when a component is selected (but no form is open)
* removed unselecting when closing forms (press <kbd>esc</kbd> again to unselect), allowing better navigation
* moved `visible-components` into a service
* added document padding if selectors would overflow top/bottom of the document
* removed janky selection of `layout` itself
* removed parent selector
* fancy new selector styles (background fade, consistent menus, animated hide/show)

![499cc462-71c0-4485-ba15-0b7d8209dd7e-1015-00003e40b88907ec](https://cloud.githubusercontent.com/assets/447522/18846245/fdeb0472-83f2-11e6-8314-81a888e84cd6.gif)
