### PR TITLE
call forms directly for a variety of actions

### DIFF
--- a/controllers/kiln-toolbar.js
+++ b/controllers/kiln-toolbar.js
@@ -1,7 +1,7 @@
 const dom = require('@nymag/dom'),
   keyCode = require('keycode'),
   events = require('../services/events'),
-  focus = require('../decorators/focus'),
+  forms = require('../services/forms'),
   select = require('../services/components/select'),
   state = require('../services/page-state'),
   progress = require('../services/progress'),
@@ -21,7 +21,7 @@ let EditorToolbar;
  * @returns {Promise}
  */
 function createPage() {
-  return focus.unfocus()
+  return forms.close()
     .then(openNewPage)
     .catch(function () {
       progress.done('error');
@@ -51,7 +51,7 @@ EditorToolbar = function (el) {
 
   // stop users from leaving the page if they have an unsaved form open!
   window.addEventListener('beforeunload', function (e) {
-    if (focus.hasCurrentFocus()) {
+    if (forms.hasOpenForm()) {
       e.returnValue = 'Are you sure you want to leave this page? Your data may not be saved.';
     }
   });
@@ -66,8 +66,8 @@ EditorToolbar = function (el) {
     if (key === 'esc') {
       if (pane.hasOpenPane()) {
         pane.close();
-      } else if (focus.hasCurrentFocus()) {
-        focus.unfocus();
+      } else if (forms.hasOpenForm()) {
+        forms.close();
       } else {
         select.unselect();
       }
@@ -105,7 +105,7 @@ EditorToolbar.prototype = {
   },
 
   onNewClick: function () {
-    if (focus.hasCurrentFocus()) {
+    if (forms.hasOpenForm()) {
       if(window.confirm('Are you sure you want to create a new page? Your data on this page may not be saved.')) { // eslint-disable-line
         return createPage();
       } // else don't leave
@@ -115,7 +115,7 @@ EditorToolbar.prototype = {
   },
 
   onPreviewClick: function () {
-    return focus.unfocus()
+    return forms.close()
       .then(openPreview)
       .catch(function () {
         progress.done('error');
@@ -129,7 +129,7 @@ EditorToolbar.prototype = {
 
   // open the publish pane if it's not already open (close other panes first)
   onPublishClick: function () {
-    return focus.unfocus()
+    return forms.close()
       .then(function () {
         // validate before opening the publish pane
         return validation.validate(rules).then(function (results) {

--- a/services/forms/index.js
+++ b/services/forms/index.js
@@ -14,7 +14,7 @@ var _ = require('lodash'),
  * Check if a form is currently open. Only one form can be open at a time.
  * @returns {boolean}
  */
-function isFormOpen() {
+function hasOpenForm() {
   return !!currentForm.ref;
 }
 
@@ -129,7 +129,7 @@ function dataChanged(serverData, formData) {
  */
 function open(ref, el, path, e) {
   // first, check if a form is already open
-  if (!isFormOpen()) {
+  if (!hasOpenForm()) {
     if (e) {
       // if there's a click event, stop it from bubbling up or doing weird things
       e.stopPropagation();
@@ -192,7 +192,7 @@ function cleanMediumEditorDom() {
 function close() {
   var container, form, ref, data;
 
-  if (isFormOpen()) {
+  if (hasOpenForm()) {
     container = findFormContainer();
     form = container && dom.find(container, 'form');
     ref = currentForm.ref;
@@ -250,10 +250,11 @@ function isFormValid() {
   }
 }
 
-exports.open = open;
-exports.close = close;
-exports.isFormValid = isFormValid;
+module.exports.open = open;
+module.exports.close = close;
+module.exports.isFormValid = isFormValid;
+module.exports.hasOpenForm = hasOpenForm;
 _.set(window, 'kiln.services.forms', module.exports); // export for plugins
 
 // for tests:
-exports.dataChanged = dataChanged;
+module.exports.dataChanged = dataChanged;


### PR DESCRIPTION
There have been a few issues with things using `focus.unfocus()` and `focus.hasCurrentFocus()` (which deals with inline and overlay forms, but not forms that are opened programmatically by anything other than a user clicking a `data-editable` element in a component) rather than calling the `forms` service directly. This included:

* <kbd>esc</kbd> not working on settings forms
* programmatic forms not being closed when opening the new page, preview, or publish pane
* "Are you sure you want to leave this page?" confirmation not being served
* "Are you sure you want to create a new page?" confirmation not being served