### PR TITLE
selector feedback

### DIFF
--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -17,7 +17,7 @@ $selector-border: #727272;
 $selector-icon: $selector-border;
 $selector-text: $selector-border;
 $selector-bg: rgba(255, 255, 255, .95); // background of selector menus
-$selector-overlay: rgba(255, 255, 255, .8); // fade other components
+$selector-overlay: rgba(255, 255, 255, .6); // fade other components
 
 // placeholder colors
 $placeholder-label: $selector-icon;

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -63,8 +63,18 @@ $selector-fade-easing: linear;
 
   @media screen and (min-width: 600px) {
     min-width: 100%;
+    opacity: 0;
     position: absolute;
+    transition: opacity 200ms linear;
     width: auto;
+  }
+}
+
+// show selector menus on hover
+.component-selector-wrapper:hover > .component-selector > .component-selector-top,
+.component-selector-wrapper:hover > .component-selector > .component-selector-bottom {
+  @media screen and (min-width: 600px) {
+    opacity: 1;
   }
 }
 

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -71,6 +71,7 @@ $selector-fade-easing: linear;
 }
 
 // show selector menus on hover
+// todo: use pointer media query when firefox supports it https://bugzilla.mozilla.org/show_bug.cgi?id=1035774
 .component-selector-wrapper:hover > .component-selector > .component-selector-top,
 .component-selector-wrapper:hover > .component-selector > .component-selector-bottom {
   @media screen and (min-width: 600px) {


### PR DESCRIPTION
* slightly less fade on background components
* on larger screens, only show selectors on hover
* (todo: [when firefox supports pointer media queries](https://bugzilla.mozilla.org/show_bug.cgi?id=1035774), use that instead of just viewport width)

![b8edbab3-9447-4304-82d8-206ee0d554cf-1015-0000b52c4c3ce997](https://cloud.githubusercontent.com/assets/447522/19043850/d1fe136e-895f-11e6-96a3-9b2f02866d7e.gif)
