### PR TITLE
Fix to Simple List Behavior to account for undefined data

### DIFF
--- a/behaviors/simple-list.js
+++ b/behaviors/simple-list.js
@@ -140,8 +140,10 @@ module.exports = function (result, args) {
       var addEl = dom.find(boundEl, '.simple-list-add'),
         allowRepeat = !!(addEl.getAttribute('data-allow-repeat') === 'true'),
         // if data is undefined make it an empty array
-        data = !data ? [] : data,
+        data = data || [],
         observer = this.observer;
+
+      observer.setValue(data);
 
       // check repeated items
       // returns true if repitition is disallowed and items repeat


### PR DESCRIPTION
this fixes a bug where if data for a Clay field that uses the `simplelist` behavior is undefined it throws two errors:

* `e.map() is in undefined`
* `... .toLowerCase is undefined`