### PR TITLE
change selector fade from 60% to 40%

### DIFF
--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -17,7 +17,7 @@ $selector-border: #727272;
 $selector-icon: $selector-border;
 $selector-text: $selector-border;
 $selector-bg: rgba(255, 255, 255, .95); // background of selector menus
-$selector-overlay: rgba(255, 255, 255, .6); // fade other components
+$selector-overlay: rgba(255, 255, 255, .4); // fade other components
 
 // placeholder colors
 $placeholder-label: $selector-icon;


### PR DESCRIPTION
Making the background slightly more opaque based on user feedback.

![screen shot 2016-10-11 at 11 22 21 am](https://cloud.githubusercontent.com/assets/447522/19276992/2c866a4c-8fa6-11e6-9bec-58ab295162aa.png)
