### PR TITLE
fix some selector hover issues

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,4 +1,5 @@
 'use strict'; // eslint-disable-line
+
 // note: use strict above is applied to the whole browserified doc
 var nodeUrl = require('url'),
   references = require('./services/references'),
@@ -67,9 +68,27 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 });
 
-// handle connection loss
+/**
+ * determine if a browser supports the (hover) media query, in any form
+ * @returns {boolean}
+ */
+function hasHoverMediaQuery() {
+  const HOVER_NONE = '(hover: none),(-moz-hover: none),(-ms-hover: none),(-webkit-hover: none)',
+    HOVER_ON_DEMAND = '(hover: on-demand),(-moz-hover: on-demand),(-ms-hover: on-demand),(-webkit-hover: on-demand)',
+    HOVER_HOVER = '(hover: hover),(-moz-hover: hover),(-ms-hover: hover),(-webkit-hover: hover)';
 
+  return window.matchMedia(`${HOVER_NONE},${HOVER_ON_DEMAND},${HOVER_HOVER}`).matches;
+}
+
+// handle connection loss and hoverability
 window.addEventListener('load', function () {
+  if (!hasHoverMediaQuery()) {
+    // firefox (and older browsers) doesn't currently support the hover media query,
+    // so we want to default to simply using old :hover
+    // rather than dynamically checking the capabilities of the browser
+    document.body.classList.add('kiln-default-hover');
+  }
+
   // test connection loss on page load
   if (!navigator.onLine) {
     // we're offline!

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -91,7 +91,7 @@ $selector-fade-easing: linear;
 .selected > .component-selector > .component-selector-top,
 .selected > .component-selector > .component-selector-bottom {
   animation-name: initialFadeInOut;
-  animation-duration: 1s;
+  animation-duration: 1.2s;
   animation-fill-mode: none;
 }
 

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -70,6 +70,16 @@ $selector-fade-easing: linear;
   }
 }
 
+// firefox shim, see below for bug ticket
+.kiln-default-hover  .component-selector-top,
+.kiln-default-hover  .component-selector-bottom {
+  min-width: 100%;
+  opacity: 0;
+  position: absolute;
+  transition: opacity 200ms linear;
+  width: auto;
+}
+
 // show selector menus on hover
 // todo: use pointer media query when firefox supports it https://bugzilla.mozilla.org/show_bug.cgi?id=1035774
 .component-selector-wrapper:hover > .component-selector > .component-selector-top,
@@ -77,6 +87,12 @@ $selector-fade-easing: linear;
   @media screen and (hover:hover) {
     opacity: 1;
   }
+}
+
+// firefox shim, see above for bug ticket
+.kiln-default-hover .component-selector-wrapper:hover > .component-selector > .component-selector-top,
+.kiln-default-hover .component-selector-wrapper:hover > .component-selector > .component-selector-bottom {
+  opacity: 1;
 }
 
 .component-selector-top {
@@ -88,12 +104,23 @@ $selector-fade-easing: linear;
   }
 }
 
+// firefox shim, see above for bug ticket
+.kiln-default-hover .component-selector-top {
+  bottom: calc(100% + #{$half-selector-offset});
+  top: auto;
+}
+
 .component-selector-bottom {
   top: calc(100% - 96px); // account for toolbar
 
   @media screen and (hover:hover) {
     top: calc(100% + #{$half-selector-offset});
   }
+}
+
+// firefox shim, see above for bug ticket
+.kiln-default-hover .component-selector-bottom {
+  top: calc(100% + #{$half-selector-offset});
 }
 
 // all menus use flex to align their buttons

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -12,6 +12,13 @@ $menu-size: 48px;
 $selector-fade-time: 150ms;
 $selector-fade-easing: linear;
 
+@keyframes initialFadeInOut {
+  0% { opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
 // component element needs to be position: relative for the selectors to display
 .component-selector-wrapper {
   position: relative;
@@ -71,13 +78,21 @@ $selector-fade-easing: linear;
 }
 
 // firefox shim, see below for bug ticket
-.kiln-default-hover  .component-selector-top,
-.kiln-default-hover  .component-selector-bottom {
+.kiln-default-hover .component-selector-top,
+.kiln-default-hover .component-selector-bottom {
   min-width: 100%;
   opacity: 0;
   position: absolute;
   transition: opacity 200ms linear;
   width: auto;
+}
+
+// briefly display selectors when selecting the component
+.selected > .component-selector > .component-selector-top,
+.selected > .component-selector > .component-selector-bottom {
+  animation-name: initialFadeInOut;
+  animation-duration: 1s;
+  animation-fill-mode: none;
 }
 
 // show selector menus on hover

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -61,7 +61,7 @@ $selector-fade-easing: linear;
   right: 0;
   position: fixed;
 
-  @media screen and (min-width: 600px) {
+  @media screen and (hover:hover) {
     min-width: 100%;
     opacity: 0;
     position: absolute;
@@ -74,7 +74,7 @@ $selector-fade-easing: linear;
 // todo: use pointer media query when firefox supports it https://bugzilla.mozilla.org/show_bug.cgi?id=1035774
 .component-selector-wrapper:hover > .component-selector > .component-selector-top,
 .component-selector-wrapper:hover > .component-selector > .component-selector-bottom {
-  @media screen and (min-width: 600px) {
+  @media screen and (hover:hover) {
     opacity: 1;
   }
 }
@@ -82,7 +82,7 @@ $selector-fade-easing: linear;
 .component-selector-top {
   top: 0;
 
-  @media screen and (min-width: 600px) {
+  @media screen and (hover:hover) {
     bottom: calc(100% + #{$half-selector-offset});
     top: auto;
   }
@@ -91,7 +91,7 @@ $selector-fade-easing: linear;
 .component-selector-bottom {
   top: calc(100% - 96px); // account for toolbar
 
-  @media screen and (min-width: 600px) {
+  @media screen and (hover:hover) {
     top: calc(100% + #{$half-selector-offset});
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,8 @@ module.exports = {
     view: './view.js'
   },
   output: {
-    path: path.join(__dirname, "dist"),
-    filename: "clay-kiln-[name].js"
+    path: path.join(__dirname, 'dist'),
+    filename: 'clay-kiln-[name].js'
   },
   module: {
     loaders: [{


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/9VWRves3/54-selector-hover-updates)
* use `hover` media query (fixes tablet hover issues)
* add firefox workaround (firefox doesn't support `hover` media query yet)
* display selectors for a second when initially selecting component (for better navigation)

![c0453853-047f-4a95-9430-1ec0406287a5-1015-000151661a900be1](https://cloud.githubusercontent.com/assets/447522/19280471/0c7a1998-8fb4-11e6-9787-846558b20943.gif)
