### PR TITLE
prevent animation jump when clicking into component

### DIFF
--- a/services/components/select.js
+++ b/services/components/select.js
@@ -114,6 +114,8 @@ function select(el) {
   unselect();
 
   // if we're clicking into element directly, don't run the initialFadeInOut animation
+  // note: we're adding an otherwise-unused css rule on :hover, which we check
+  // when selecting to see if the mouse/pointer is currently hovering over the element
   if (getComputedStyle(component).getPropertyValue('backface-visibility') === 'hidden') {
     component.classList.add('kiln-suppress-animation');
   }

--- a/services/components/select.js
+++ b/services/components/select.js
@@ -113,6 +113,11 @@ function select(el) {
   // only one component can be selected at a time
   unselect();
 
+  // if we're clicking into element directly, don't run the initialFadeInOut animation
+  if (getComputedStyle(component).getPropertyValue('backface-visibility') === 'hidden') {
+    component.classList.add('kiln-suppress-animation');
+  }
+
   // selected component gets .selected, parent gets .selected-parent
   if (component && component.tagName !== 'HTML') {
     component.classList.add('selected');
@@ -130,6 +135,7 @@ function unselect() {
   var current = currentSelected || dom.find('.component-selector-wrapper.selected');
 
   if (current) {
+    current.classList.remove('kiln-suppress-animation'); // unsuppress initialFadeInOut animation
     current.classList.remove('selected');
     removePadding();
     window.kiln.trigger('unselect', current);

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -104,7 +104,7 @@ $selector-fade-easing: linear;
 
 // to determine if an element is being hovered at the time it's selected,
 // we add an otherwise-unused css rule to that element on :hover
-// we have to do this because there's no way to determine this other than
+// we have to do this because there's no way to determine mouse position other than
 // adding a WHOLE BUNCH of mouse events to the dom, which is gross and nonperformant
 .component-selector-wrapper:hover {
   @media screen and (hover:hover) {

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -102,12 +102,17 @@ $selector-fade-easing: linear;
   animation: none;
 }
 
+// to determine if an element is being hovered at the time it's selected,
+// we add an otherwise-unused css rule to that element on :hover
+// we have to do this because there's no way to determine this other than
+// adding a WHOLE BUNCH of mouse events to the dom, which is gross and nonperformant
 .component-selector-wrapper:hover {
   @media screen and (hover:hover) {
     backface-visibility: hidden; // unused style to test if mouse is inside element
   }
 }
 
+// firefox shim, see below for bug ticket
 .kiln-default-hover .component-selector-wrapper:hover {
   backface-visibility: hidden; // unused style to test if mouse is inside element
 }

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -95,6 +95,23 @@ $selector-fade-easing: linear;
   animation-fill-mode: none;
 }
 
+// suppress initialFadeInOut animation if we're currently hovered over an element
+// when selecting it
+.kiln-suppress-animation.selected > .component-selector > .component-selector-top,
+.kiln-suppress-animation.selected > .component-selector > .component-selector-bottom {
+  animation: none;
+}
+
+.component-selector-wrapper:hover {
+  @media screen and (hover:hover) {
+    backface-visibility: hidden; // unused style to test if mouse is inside element
+  }
+}
+
+.kiln-default-hover .component-selector-wrapper:hover {
+  backface-visibility: hidden; // unused style to test if mouse is inside element
+}
+
 // show selector menus on hover
 // todo: use pointer media query when firefox supports it https://bugzilla.mozilla.org/show_bug.cgi?id=1035774
 .component-selector-wrapper:hover > .component-selector > .component-selector-top,


### PR DESCRIPTION
Prevents the animation from running if you select something _while hovered over it_ (which would otherwise cause the animation to run, then flash over to the hover state)