### PR TITLE
Fix a bug in Kiln that was caused by not inheriting flex properties.

### DIFF
--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -275,7 +275,6 @@ $selector-fade-easing: linear;
 // (this will display properly if their parents are either flexed OR box)
 .component-list-inner {
   display: inherit;
-  flex-flow: row wrap;
   flex-direction: inherit;
   flex-wrap: inherit;
   flex: 1 1 100%;

--- a/styleguide/component-select.scss
+++ b/styleguide/component-select.scss
@@ -276,5 +276,7 @@ $selector-fade-easing: linear;
 .component-list-inner {
   display: inherit;
   flex-flow: row wrap;
+  flex-direction: inherit;
+  flex-wrap: inherit;
   flex: 1 1 100%;
 }


### PR DESCRIPTION
Adding components to components which are component lists in edit mode does not accurately reflect what they look like in view mode.

For example, the image below is what adding components (images) to a component list component looks like in edit mode.
<img width="467" alt="exhibita" src="https://cloud.githubusercontent.com/assets/2770126/19977098/c3de77c0-a1c8-11e6-8203-03c2629e69c4.png">

However, this is how it looks like in view mode.
<img width="516" alt="exhibitb" src="https://cloud.githubusercontent.com/assets/2770126/19977099/c3e05b3a-a1c8-11e6-88bd-eea1a3c7a125.png">

This was caused by not inheriting `flex-wrap` and `flex-direction` from the parent. Now this is what it looks like in edit mode, as it should.
<img width="497" alt="exhibitc" src="https://cloud.githubusercontent.com/assets/2770126/19977204/36307fd0-a1c9-11e6-90c5-b61f933969f5.png">
