### PR TITLE
Move `toolbar-layer` above `overlay-layer`

### DIFF
--- a/styleguide/_layers.scss
+++ b/styleguide/_layers.scss
@@ -6,12 +6,12 @@
   z-index: 1000;
 }
 
-@mixin toolbar-layer {
-  z-index: 1010;
-}
-
 @mixin overlay-layer {
   z-index: 1020;
+}
+
+@mixin toolbar-layer {
+  z-index: 1021;
 }
 
 @mixin datepicker-layer {


### PR DESCRIPTION
Otherwise elements in the `kiln-toolbar-pane` are beneath elements in the `editor-overlay`

One example of this is a field edited in `_display: overlay` that opens a mediaplay image picker, which renders within the `kiln-toolbar-pane`