### PR TITLE
Add formatUrl transform to magic button

### DIFF
--- a/behaviors/magic-button.md
+++ b/behaviors/magic-button.md
@@ -7,6 +7,7 @@ Append a magic button to an input.
 * **field** _(optional)_ a field to grab the value from
 * **component** _(optional)_ a name of a component to grab the component ref from
 * **transform** _(optional)_ a transform to apply to the grabbed value
+* **transformArg** _(optional)_ an argument to pass through to the transform
 * **url** _(optional)_ to get data from
 * **property** _(optional)_ to get from the returned data
 * **moreMagic** _(optional)_ to run the returned value through more transforms, api calls, etc
@@ -17,6 +18,7 @@ Magic buttons are extremely powerful, but can be a little confusing to configure
 
 1. specify a `field` or `component`. The button will grab the value or ref, respectively
 2. specify a `transform`. Transforms are useful when doing api calls with that data
+2. specify a `transformArg` if you need to send more information to the transform.
 3. specify a `url` to do the api call against. It will do a GET request to `url + transformed data`
 4. specify a `property` to grab from the result of that api call. You can use `_.get()` syntax, e.g. `foo.bar[0].baz`
 5. add `moreMagic` if you need to do anything else to the returned data
@@ -63,6 +65,14 @@ moreMagic:
     transform: mediaplayUrl (to change the image url into a string we can query mediaplay's api with)
     url: [mediaplay api url]
     property: metadata.caption
+```
+
+### (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧ "grab the show name and use it to automatically format an image url"
+
+```yaml
+field: showName
+transform: formatUrl
+transformArg: [base image url]/recaps-$DATAFIELD.png ($DATAFIELD is the placeholder in our formatUrl transform)
 ```
 
 ☆.。.:*・°☆.。.:*・°☆.。.:*・°☆.。.:*・°☆

--- a/behaviors/magic-button.test.js
+++ b/behaviors/magic-button.test.js
@@ -75,6 +75,17 @@ describe(dirname, function () {
           .then(expectData);
       });
 
+      it('uses a transform with an argument on the data', function () {
+        var bindings = { magicTest1: { data: { value: '' }}};
+
+        function expectData() {
+          expect(bindings.magicTest1.data.value).to.equal('http://nymag.com/tags/hello/');
+        }
+
+        fn(null, bindings, dom.create('<a class="magic-button" data-magic-currentField="magicTest1" data-magic-field="magicTest2" data-magic-transform="formatUrl" data-magic-transformArg="http://nymag.com/tags/$DATAFIELD/"></a>'))
+          .then(expectData);
+      });
+
       it('calls a url', function () {
         var bindings = { magicTest1: { data: { value: '' }}};
 
@@ -148,6 +159,23 @@ describe(dirname, function () {
 
       it('passes through speakingurl', function () {
         expect(fn('Don\'t Blink')).to.equal('dont-blink');
+      });
+    });
+
+    describe('transforms » formatUrl', function () {
+      var fn = lib.transformers.formatUrl,
+        format = 'http://pixel.nymag.com/imgs/custom/tvrecaps/recaps-$DATAFIELD-160x160.png';
+
+      it('returns an empty string if no format is provided', function () {
+        expect(fn('TV Show')).to.equal('');
+      });
+
+      it('replaces placeholder with data field', function () {
+        expect(fn('TV Show', format)).to.equal('http://pixel.nymag.com/imgs/custom/tvrecaps/recaps-tv-show-160x160.png');
+      });
+
+      it('removes html tags', function () {
+        expect(fn('Foo<br /> <h1>Bar</h1>', format)).to.equal('http://pixel.nymag.com/imgs/custom/tvrecaps/recaps-foo-bar-160x160.png');
       });
     });
   });


### PR DESCRIPTION
Adds a new transform `formatUrl` to the magic button, as well as a new optional `transformArg` property which is passed to transforms. This allows the button to take a field and transform it to a url of a given format.

This is required for the episode recap component for Vulture, which needs a magic button to automatically create an image url based on the show name.