### PR TITLE
redesigned status messages

### DIFF
--- a/controllers/directory-pane.js
+++ b/controllers/directory-pane.js
@@ -33,7 +33,7 @@ module.exports = function () {
 
       e.preventDefault();
 
-      progress.start('page');
+      progress.start('save');
       return db.get(uri)
         .then(function (data) {
           _.assign(data, { name: name, title: title });

--- a/controllers/directory-pane.js
+++ b/controllers/directory-pane.js
@@ -41,12 +41,9 @@ module.exports = function () {
             .then(function () {
               pane.close();
               progress.done();
-              progress.open('page', 'User Updated!', true);
+              progress.open('save', 'User Updated!');
             });
-        }).catch(function (e) {
-          progress.done('error');
-          progress.open('error', `Error saving user: ${e.message}`, true);
-        });
+        }).catch(progress.error('Error saving user'));
     },
 
     onLogout: function (e) {

--- a/controllers/kiln-toolbar-edit.js
+++ b/controllers/kiln-toolbar-edit.js
@@ -25,10 +25,7 @@ let EditorToolbar;
 function createPage() {
   return forms.close()
     .then(openNewPage)
-    .catch(function () {
-      progress.done('error');
-      progress.open('error', 'Issue with opening page options.', true);
-    });
+    .catch(progress.error('Error opening new pages list'));
 }
 
 /**
@@ -84,9 +81,8 @@ EditorToolbar = function (el) {
       state.openDynamicSchedule(res.scheduledAt, res.publishedUrl);
     } else if (res.published) {
       state.toggleButton('published', true);
-      progress.open('publish', `Page is currently published: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
     }
-  });
+  }).catch(progress.error('Error getting page state'));
 };
 
 /**
@@ -112,10 +108,7 @@ EditorToolbar.prototype = {
   onPreviewClick: function () {
     return forms.close()
       .then(openPreview)
-      .catch(function () {
-        progress.done('error');
-        progress.open('error', 'Data could not be saved. Please review your open form.', true);
-      });
+      .catch(progress.error('Error opening preview'));
   },
 
   onViewClick: toggleEdit,
@@ -128,16 +121,12 @@ EditorToolbar.prototype = {
         return validation.validate(rules).then(function (results) {
           if (results.errors.length) {
             progress.done('error');
+            progress.open('error', 'Error opening publish', results.errors.join(', '));
           }
 
-          openPublish(results);
+          return openPublish(results);
         });
-      })
-      .catch(function () {
-        // if we can't unfocus the current form...
-        progress.done('error');
-        progress.open('error', 'Data could not be saved. Please review your open form.', true);
-      });
+      }).catch(progress.error('Error opening publish'));
   }
 };
 

--- a/controllers/kiln-toolbar-view.js
+++ b/controllers/kiln-toolbar-view.js
@@ -37,7 +37,6 @@ EditorToolbar = function (el) {
       state.openDynamicSchedule(res.scheduledAt, res.publishedUrl);
     } else if (res.published) {
       state.toggleButton('published', true);
-      progress.open('publish', `Page is currently published: <a href="${res.publishedUrl}" target="_blank">View Page</a>`);
     }
   });
 };

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -235,7 +235,7 @@ module.exports = function () {
       }
 
       pane.close();
-      progress.start('page');
+      progress.start('save');
 
       return db.get(dom.pageUri())
         .then(function (page) {
@@ -243,7 +243,7 @@ module.exports = function () {
           return db.save(dom.pageUri(), page);
         })
         .then(function () {
-          progress.done('page');
+          progress.done();
           if (url) {
             // if we're saving, say that
             progress.open('page', 'Saved custom page url', true);

--- a/controllers/publish-pane.js
+++ b/controllers/publish-pane.js
@@ -101,15 +101,11 @@ module.exports = function () {
             var url = promises[0];
 
             progress.done();
-            progress.open('publish', `Published! <a href="${url}" target="_blank">View Page</a>`);
+            progress.open('publish', 'Published', `<a href="${url}" target="_blank">View</a>`);
             state.toggleButton('scheduled', false);
             state.toggleButton('published', true);
           })
-          .catch(function () {
-            // note: the Error passed into this doesn't have a message, so we use a custom one
-            progress.done('error');
-            progress.open('error', 'Server errored when publishing, please try again.', true);
-          });
+          .catch(progress.error('Error publishing'));
       });
     },
 
@@ -126,11 +122,7 @@ module.exports = function () {
           // per #304, reload the page at the page url, not the published url
           window.location.href = db.uriToUrl(pageUri) + '.html?edit=true';
         })
-        .catch(function () {
-          // note: the Error passed into this doesn't have a message, so we use a custom one
-          progress.done('error');
-          progress.open('error', 'Server errored when unpublishing, please try again.', true);
-        });
+        .catch(progress.error('Error unpublishing'));
     },
 
     onScheduleInput: function () {
@@ -170,13 +162,9 @@ module.exports = function () {
         return schedulePageAndLayout(timestamp)
           .then(function () {
             progress.done();
-            state.openDynamicSchedule(timestamp, db.uriToUrl(pageUri));
+            state.openDynamicSchedule(timestamp, db.uriToUrl(pageUri), true);
           })
-          .catch(function () {
-            // note: the Error passed into this doesn't have a message, so we use a custom one
-            progress.done('error');
-            progress.open('error', 'Server errored when scheduling, please try again.', true);
-          });
+          .catch(progress.error('Error scheduling'));
       });
     },
 
@@ -187,14 +175,10 @@ module.exports = function () {
       return unschedulePageAndLayout()
         .then(function () {
           progress.done();
-          progress.open('schedule', 'Unscheduled!', true);
+          progress.open('schedule', 'Unscheduled');
           state.toggleButton('scheduled', false);
         })
-        .catch(function () {
-          // note: the Error passed into this doesn't have a message, so we use a custom one
-          progress.done('error');
-          progress.open('error', 'Server errored when unscheduling, please try again.', true);
-        });
+        .catch(progress.error('Error unscheduling'));
     },
 
     onCustomUrlInput: function (e) {
@@ -246,16 +230,13 @@ module.exports = function () {
           progress.done();
           if (url) {
             // if we're saving, say that
-            progress.open('page', 'Saved custom page url', true);
+            progress.open('save', 'Saved custom page url');
           } else {
             // if we're explicitly removing a custom url, say that
-            progress.open('page', 'Removed custom page url', true);
+            progress.open('save', 'Removed custom page url');
           }
         })
-        .catch(function () {
-          progress.done('error');
-          progress.open('error', 'Server errored when saving page url, please try again.', true);
-        });
+        .catch(progress.error('Error saving custom page url'));
     }
   };
   return Constructor;

--- a/edit.js
+++ b/edit.js
@@ -96,7 +96,7 @@ window.addEventListener('load', function () {
   // test connection loss on page load
   if (!navigator.onLine) {
     // we're offline!
-    progress.open('offline', connectionLostMessage);
+    progress.open('offline', connectionLostMessage, null, true);
   }
 });
 
@@ -106,7 +106,7 @@ window.addEventListener('online', function () {
 
 window.addEventListener('offline', function () {
   progress.done('offline'); // turn any progress indicators to grey and end them
-  progress.open('offline', connectionLostMessage);
+  progress.open('offline', connectionLostMessage, null, true);
 });
 
 new Konami(takeOffEveryZig);

--- a/services/components/add-component.js
+++ b/services/components/add-component.js
@@ -113,11 +113,7 @@ function addToProp(args, pane) {
  * @returns {Promise}
  */
 function addComponent(pane, field, name, prevRef) {
-  if (dom.closest(pane, '.kiln-page-area')) {
-    progress.start('page');
-  } else {
-    progress.start('layout');
-  }
+  progress.start('save');
   removeParentPlaceholder(field);
   return Promise.all([edit.createComponent(name), edit.getData(field.ref)])
     .then(function (promises) {

--- a/services/components/head-components.js
+++ b/services/components/head-components.js
@@ -283,11 +283,7 @@ function updateOrder(ref, path, data) {
             progress.done();
             window.kiln.trigger('save', data);
           })
-          .catch(function (e) {
-            console.error(e.message, e.stack);
-            progress.done('error');
-            progress.open('error', 'A server error occured. Please try again.', true);
-          });
+          .catch(progress.error('Error saving head components'));
       });
     }
   };

--- a/services/components/head-components.js
+++ b/services/components/head-components.js
@@ -275,7 +275,7 @@ function updateOrder(ref, path, data) {
       let pageUri = dom.pageUri();
 
       // component list is in the page. swap it and save
-      progress.start('page'); // set progress manually
+      progress.start('save'); // set progress manually
       return edit.getDataOnly(pageUri).then(function (pageData) {
         pageData[path] = list; // array of refs
         return db.save(pageUri, _.omit(pageData, '_ref'))
@@ -303,7 +303,7 @@ function removeComponentFromList(ref, path) {
   return function (id) {
     var node = getComponentNode(id);
 
-    progress.start('layout');
+    progress.start('save');
     removeComponentFromDOM(node);
     return edit.removeFromParentList({
       el: node,

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -104,6 +104,18 @@ function addTextHeader(obj) {
 }
 
 /**
+ * handle errors thrown by fetch itself, e.g. connection refused
+ * @param  {string} url    url we're trying to fetch
+ * @param  {string} method
+ * @return {object}        with `statusText` for checkStatus to handle
+ */
+function checkError(url, method) {
+  return function () {
+    return { statusText: `Cannot ${method} ${url}` };
+  };
+}
+
+/**
  * check status of a request, passing through data on 2xx and 3xx
  * and erroring on 4xx and 5xx
  * @param {object} res
@@ -136,7 +148,9 @@ function send(options) {
   // add credentials. this tells fetch to pass along cookies, incl. auth
   options.credentials = 'same-origin';
 
-  return rest.send(uriToUrl(options.url), options).then(checkStatus);
+  return rest.send(uriToUrl(options.url), options)
+    .catch(checkError(uriToUrl(options.url), options.method))
+    .then(checkStatus);
 }
 
 /**

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -122,7 +122,7 @@ function checkError(method) {
  * @throws error on non-200/300 response status
  */
 function checkStatus(res) {
-  if (res.status >= 200 && res.status < 400) {
+  if (res.status && res.status >= 200 && res.status < 400) {
     return res;
   } else {
     let error = new Error(res.statusText);

--- a/services/edit/db.js
+++ b/services/edit/db.js
@@ -105,13 +105,12 @@ function addTextHeader(obj) {
 
 /**
  * handle errors thrown by fetch itself, e.g. connection refused
- * @param  {string} url    url we're trying to fetch
  * @param  {string} method
  * @return {object}        with `statusText` for checkStatus to handle
  */
-function checkError(url, method) {
-  return function () {
-    return { statusText: `Cannot ${method} ${url}` };
+function checkError(method) {
+  return function apiError() {
+    return { statusText: `Cannot ${method === 'GET' ? 'get' : 'send'} data` };
   };
 }
 
@@ -149,7 +148,7 @@ function send(options) {
   options.credentials = 'same-origin';
 
   return rest.send(uriToUrl(options.url), options)
-    .catch(checkError(uriToUrl(options.url), options.method))
+    .catch(checkError(options.method))
     .then(checkStatus);
 }
 

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -96,15 +96,10 @@ function validate(data, schema) {
  */
 function save(data) {
   var uri = data[refProp],
-    schemaPromise = data._schema && Promise.resolve(data._schema) || cache.getSchema(uri),
-    el = dom.find(`[${references.referenceAttribute}="${uri}"]`);
+    schemaPromise = data._schema && Promise.resolve(data._schema) || cache.getSchema(uri);
 
   // todo: this doesn't handle component lists in the head
-  if (el && dom.closest(el, '.kiln-page-area')) {
-    progress.start('page');
-  } else {
-    progress.start('layout');
-  }
+  progress.start('save');
 
   // get the schema and validate data
   return schemaPromise.then(function (schema) {

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -114,11 +114,7 @@ function save(data) {
           window.kiln.trigger('save', data);
           return savedData;
         })
-        .catch(function (e) {
-          console.error(e.message, e.stack);
-          progress.done('error');
-          progress.open('error', 'A server error occured. Please try again.', true);
-        });
+        .catch(progress.error('Error saving component'));
     }
   });
 }

--- a/services/page-state.js
+++ b/services/page-state.js
@@ -194,22 +194,23 @@ function timeout(fn, date) {
 }
 
 // convenience method for dynamic schedule message
-function openDynamicSchedule(time, url) {
-  // open a schedule status message
-  progress.open('schedule', `Scheduled to publish ${formatTime(time)}`);
+function openDynamicSchedule(time, url, showStatusMessage) {
   toggleButton('scheduled', true);
-  // set it to dynamically change to publish if the page is still open
+  if (showStatusMessage) {
+    progress.open('schedule', 'Scheduled', `<a href="${url}.html" target="_blank">Preview</a>`);
+  }
+  // set button to dynamically change to publish if the page is still open
   // (or if a new user opens the page) when it's set to publish
   timeout(function () {
     progress.close();
-    // close the schedule status, wait a beat (drawing the eye of the user), then open the published status
+    // Wait a beat (drawing the eye of the user), then open the published status
     // Normally, transitions between status messages happen instantaneously,
     // because they're initiated by user actions (e.g. a published page being scheduled to re-publish).
     // Because this specific transition happens without user action (rather, it's on a timeout),
     // we need to draw the user's eye and allow them to grasp what's going on
     // (without being obtrusive)
     window.setTimeout(function () {
-      progress.open('publish', `Published! <a href="${url}@published.html" target="_blank">View Page</a>`);
+      progress.open('publish', 'Published', `<a href="${url}@published.html" target="_blank">View</a>`);
       // and remember to toggle the button
       toggleButton('scheduled', false);
       toggleButton('published', true);

--- a/services/pane/new-page.js
+++ b/services/pane/new-page.js
@@ -53,7 +53,7 @@ function addCurrentPage(current) {
         id = _.last(dom.pageUri().split('/'));
 
       e.preventDefault();
-      progress.start('page');
+      progress.start('save');
       current.push({
         id: id,
         title: value
@@ -62,7 +62,7 @@ function addCurrentPage(current) {
       return db.save(site.get('prefix') + '/lists/new-pages', current)
       .then(function () {
         pane.close();
-        progress.done('page');
+        progress.done();
         progress.open('page', `<em>${value}</em> added to new pages list`, true);
       })
       .catch(function () {

--- a/services/pane/new-page.js
+++ b/services/pane/new-page.js
@@ -20,10 +20,7 @@ function createPageByType(id) {
     .then(function (url) {
       location.href = url;
     })
-    .catch(function () {
-      progress.done('error');
-      progress.open('error', 'Error creating new page', true);
-    });
+    .catch(progress.error('Error creating new page'));
 }
 
 /**
@@ -65,10 +62,7 @@ function addCurrentPage(current) {
         progress.done();
         progress.open('page', `<em>${value}</em> added to new pages list`, true);
       })
-      .catch(function () {
-        progress.done('error');
-        progress.open('error', 'Error creating new page', true);
-      });
+      .catch(progress.error('Error adding current page'));
     });
 
     dom.replaceElement(el, form);

--- a/services/progress.js
+++ b/services/progress.js
@@ -111,7 +111,10 @@ function open(color, message, action, permanent) {
  * close status message
  */
 function close() {
-  getStatusEl().classList.remove('on');
+  var statusEl = getStatusEl();
+
+  statusEl.innerHTML = ''; // clear any message/action from before
+  statusEl.classList.remove('on');
 }
 
 /**

--- a/services/progress.js
+++ b/services/progress.js
@@ -4,13 +4,12 @@ var _ = require('lodash'),
   boxShadow = '0 0 10px 0',
   colors = {
     // these are taken from styleguide/_colors.scss
-    draft: '#a17355',
-    publish: '#149524',
+    draft: '#c8b585',
+    scheduled: '#d39d22',
+    published: '#149524',
     offline: '#888',
-    error: '#DD2F1C',
-    schedule: '#cc8e28',
-    page: '#1782A9',
-    layout: '#694C79'
+    error: '#a86667',
+    save: '#229ed3'
   },
   timeoutMilliseconds = 3500; // should be the same timeout for every status message
 

--- a/services/progress.test.js
+++ b/services/progress.test.js
@@ -72,7 +72,7 @@ describe(dirname, function () {
       var fn = lib[this.title];
 
       it('opens status message', function () {
-        var message = '<span>hello</span>';
+        var message = 'hello';
 
         function expectNull() {
           expect(document.querySelector('.kiln-status').classList.contains('on')).to.equal(false);
@@ -81,9 +81,26 @@ describe(dirname, function () {
         }
 
         stubStatus();
-        fn('save', message, true);
+        fn('save', message);
         expect(document.querySelector('.kiln-status').classList.contains('on')).to.equal(true);
-        expect(document.querySelector('.kiln-status').innerHTML).to.equal(message);
+        expect(document.querySelector('.kiln-status').innerHTML).to.equal(`<div class="kiln-status-message">${message}</div>`);
+        setTimeout(expectNull, lib.timeoutMilliseconds);
+      });
+
+      it('opens status message with an action', function () {
+        var message = 'hello',
+          action = '<a href="http://google.com">ok google</a>';
+
+        function expectNull() {
+          expect(document.querySelector('.kiln-status').classList.contains('on')).to.equal(false);
+          lib.close();
+          done();
+        }
+
+        stubStatus();
+        fn('save', message, action);
+        expect(document.querySelector('.kiln-status').classList.contains('on')).to.equal(true);
+        expect(document.querySelector('.kiln-status').innerHTML).to.equal(`<div class="kiln-status-message">${message}</div><div class="kiln-status-action">${action}</div>`);
         setTimeout(expectNull, lib.timeoutMilliseconds);
       });
     });

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -1,7 +1,7 @@
 // states (used by progress bar, status message, publish button)
 $draft: #c8b585;
-$scheduled: #d39d22;
-$published: #149524;
+$scheduled: #d29c31;
+$published: #599f61;
 $offline: #888;
 $error: #a86667;
 $save: #229ed3;

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -1,7 +1,10 @@
-// Publish state
+// states (used by progress bar, status message, publish button)
 $draft: #c8b585;
 $scheduled: #d39d22;
 $published: #149524;
+$offline: #888;
+$error: #a86667;
+$save: #229ed3;
 
 // Toolbar - View Mode
 $toolbar-view: #585c60;

--- a/styleguide/progress.scss
+++ b/styleguide/progress.scss
@@ -22,13 +22,16 @@
 .kiln-status {
   @include primary-text();
 
+  align-items: center;
   bottom: 100%;
   color: $white;
+  display: flex;
+  justify-content: space-between;
   left: 0;
-  padding: 4px 10px;
+  padding: 15px;
   position: absolute;
   text-align: center;
-  transform: translateY(30px);
+  transform: translateY(50px);
   transition: transform 150ms ease-out;
   width: 100%;
 


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/EYkRev1i/62-clay-status-messages)
* new semantic colors (slightly more pastel than before)
* larger status message (now that they aren't permanent)
* removed permanent status messages (schedule and publish)
* merged `page` and `layout` colors into `save` (blue)
* created `progress.error` convenience method to pass errors through
* note: `offline` status message will be permanent until you reconnect
* passing in error messages directly to error status messages now

![screen shot 2016-12-05 at 4 13 42 pm](https://cloud.githubusercontent.com/assets/447522/20902616/da048b38-bb05-11e6-8ec2-fb3c412f4bb1.png)

![screen shot 2016-12-05 at 4 14 31 pm](https://cloud.githubusercontent.com/assets/447522/20902636/f2588680-bb05-11e6-8673-6ef57a287110.png)

![screen shot 2016-12-05 at 4 15 43 pm](https://cloud.githubusercontent.com/assets/447522/20902667/1c518892-bb06-11e6-9bc5-ee80bd85e474.png)

