### PR TITLE
Exposes layout object to validators

### DIFF
--- a/services/publish-validation.js
+++ b/services/publish-validation.js
@@ -94,12 +94,17 @@ function mapRules(rules, state) {
  */
 function validate(rules) {
   var refs = getLatestRefMap(),
-    components = getComponentMap(refs);
+    components = getComponentMap(refs),
+    layoutRef = document.documentElement.getAttribute('data-layout-uri');
 
   // run rules async
-  return promises.join(getLatestRefDataMap(refs), components)
+  return promises.join(getLatestRefDataMap(refs), components, edit.getData(layoutRef))
     .then(function (result) {
-      var state = control.setReadOnly({ refs: result[0], components: result[1] });
+      var state = control.setReadOnly({
+        refs: result[0],
+        components: result[1],
+        layout: result[2]
+      });
 
       return mapRules(rules, state);
     });

--- a/services/publish-validation.test.js
+++ b/services/publish-validation.test.js
@@ -14,6 +14,7 @@ describe('publish-validation service', function () {
     sandbox.spy(dom, 'create');
     sandbox.stub(dom, 'find');
     sandbox.stub(dom, 'findAll');
+    sandbox.stub(document.documentElement, 'getAttribute'),
     sandbox.stub(edit);
   });
 
@@ -76,9 +77,19 @@ describe('publish-validation service', function () {
 
       dom.findAll.withArgs('[data-uri]').returns([dom.create('<section data-uri="' + ref + '" />')]);
       edit.getData.withArgs(ref).returns(Promise.resolve(data));
+      document.documentElement.getAttribute.withArgs('data-layout-uri').returns('localhost/selectall/components/layout/instances/article');
+      edit.getData.withArgs('localhost/selectall/components/layout/instances/article').returns(Promise.resolve({foo: 'bar'}));
 
       return fn(rules).then(function () {
-        expect(spy.args[0][0]).to.deep.equal({refs: {'/components/a': {}}, components: ['a']});
+        expect(spy.args[0][0]).to.deep.equal({
+          refs: {
+            '/components/a': {}
+          },
+          components: ['a'],
+          layout: {
+            foo: 'bar'
+          }
+        });
       });
     });
   });

--- a/validators/README.md
+++ b/validators/README.md
@@ -14,7 +14,7 @@ A longer description that explains the validation error.
 
 ### validate
 
-A function that returns an array of warnings/errors (return an empty array if all rules pass). It receives a frozen `state` object with refs and components. For example, the following validator warns when `tk` exists in article headlines and paragraphs:
+A function that returns an array of warnings/errors (return an empty array if all rules pass). It receives a frozen `state` object with refs, components, and the page's layout object. For example, the following validator warns when `tk` exists in article headlines and paragraphs:
 
 ```js
 var label = 'TKs';
@@ -25,8 +25,11 @@ var label = 'TKs';
   };
 
 /**
- * @param {{refs: object, components: Array}} state
- * @returns {[object]} errors
+ * @param {Object} state
+ * @param {Object} state.refs
+ * @param {Array} state.components
+ * @param {Object} state.layout
+ * @returns {Object[]} errors
  */
 function validate(state) {
   var errors = [],


### PR DESCRIPTION
This change passes the layout object to validation functions so we can develop layout-specific rules. (Relevant [Trello](https://trello.com/c/srUYDxPl/1316-rendition-layout-pre-publish-validation))