### PR TITLE
Adding back `selected-parent` class

### DIFF
--- a/services/components/select.js
+++ b/services/components/select.js
@@ -16,7 +16,8 @@ var _ = require('lodash'),
   visibleComponents = require('./visible-components'),
   hidden = 'kiln-hide',
   selectorHeight = 56, // selector menus are 48px tall, offset is 8px
-  currentSelected;
+  currentSelected,
+  currentSelectedParent;
 
 /**
  * Get the closest component element from the DOM. Checks self and then parents.
@@ -108,7 +109,8 @@ function removePadding() {
  * @param {MouseEvent} e
  */
 function select(el) {
-  var component = getComponentEl(el);
+  var component = getComponentEl(el),
+    parent = getParentEl(component);
 
   // only one component can be selected at a time
   unselect();
@@ -123,8 +125,10 @@ function select(el) {
   // selected component gets .selected, parent gets .selected-parent
   if (component && component.tagName !== 'HTML') {
     component.classList.add('selected');
+    parent.classList.add('selected-parent');
     addPadding(component);
     currentSelected = component;
+    currentSelectedParent = parent;
   }
 
   window.kiln.trigger('select', component);
@@ -134,7 +138,8 @@ function select(el) {
  * remove selection
  */
 function unselect() {
-  var current = currentSelected || dom.find('.component-selector-wrapper.selected');
+  var current = currentSelected || dom.find('.component-selector-wrapper.selected'),
+    currentParent = current ? currentSelectedParent || getParentEl(current) : null;
 
   if (current) {
     current.classList.remove('kiln-suppress-animation'); // unsuppress initialFadeInOut animation
@@ -143,7 +148,12 @@ function unselect() {
     window.kiln.trigger('unselect', current);
   }
 
+  if (currentParent) {
+    currentParent.classList.remove('selected-parent');
+  }
+
   currentSelected = null;
+  currentSelectedParent = null;
 }
 
 /**

--- a/services/components/select.js
+++ b/services/components/select.js
@@ -122,12 +122,16 @@ function select(el) {
     component.classList.add('kiln-suppress-animation');
   }
 
-  // selected component gets .selected, parent gets .selected-parent
+  // selected component gets .selected
   if (component && component.tagName !== 'HTML') {
     component.classList.add('selected');
-    parent.classList.add('selected-parent');
     addPadding(component);
     currentSelected = component;
+  }
+
+  // if there's a parent it gets .selected-parent
+  if (parent) {
+    parent.classList.add('selected-parent');
     currentSelectedParent = parent;
   }
 

--- a/services/components/select.test.js
+++ b/services/components/select.test.js
@@ -55,6 +55,18 @@ describe(dirname, function () {
         fn(el);
         expect(el.classList.contains('selected')).to.equal(true);
       });
+
+      it('adds .selected-parent class to parent component', function () {
+        var el = stubEditableElement(),
+          parent = stubComponent(),
+          component = stubComponent();
+
+        component.appendChild(el);
+        parent.appendChild(component);
+
+        fn(el);
+        expect(parent.classList.contains('selected-parent')).to.equal(true);
+      });
     });
 
     describe('unselect', function () {
@@ -69,6 +81,19 @@ describe(dirname, function () {
         lib.select(el);
         fn(); // unselect
         expect(component.classList.contains('selected')).to.equal(false);
+      });
+
+      it('removed .selected-parent class from component parent', function () {
+        var el = stubEditableElement(),
+          component = stubComponent(),
+          parent = stubComponent();
+
+        component.appendChild(el);
+        parent.appendChild(component);
+
+        lib.select(el);
+        fn(); // unselect
+        expect(parent.classList.contains('selected-parent')).to.equal(false);
       });
     });
 


### PR DESCRIPTION
As components grow more complex, sometimes we need to write styles specific to edit mode. Sometimes in this situation we need awareness of when a component's parent is selected. There used to be a class for this, but in some updates it seems to have been removed. This adds that class back in. 

**Example**
The `in-article-slideshow` component has a component-list of slides. If we want these all to be editable we need to show them all on the page, which makes the page very long _and_ makes it so that the component cannot be dragged to different locations on the page. By having selected mode styles only we can maintain it's proper appearance and only expand it when we want to edit the component.

**When not editing**
![screen shot 2016-12-27 at 10 33 03 am](https://cloud.githubusercontent.com/assets/4906712/21502735/fd0e9bf2-cc1f-11e6-8fbd-02dabb5692a3.png)

**When Editing**
![screen shot 2016-12-27 at 10 33 20 am](https://cloud.githubusercontent.com/assets/4906712/21502743/09b7e07a-cc20-11e6-995b-10e7b35b279e.png)



