### PR TITLE
paste fixes

### DIFF
--- a/behaviors/wysiwyg.js
+++ b/behaviors/wysiwyg.js
@@ -74,8 +74,9 @@ function splitParagraphs(str) {
  */
 function matchComponents(strings, rules) {
   return _(strings).map(function (str) {
-    // remove extraneous opening <p> and <div> tags
-    var cleanStr = str.replace(/^\s?<(?:p|div)(?:\s?\/)?>/ig, ''),
+    // remove extraneous opening <p>, <div>, and <br> tags
+    // note: some google docs pastes might have `<p><br>`
+    var cleanStr = str.replace(/^\s?<(?:p><br|p|div|br)(?:\s?\/)?>\s?/ig, ''),
       matchedRule = _.find(rules, function matchRule(rule) {
         return rule.match.exec(cleanStr);
       }),
@@ -108,9 +109,9 @@ function matchComponents(strings, rules) {
     // this happens a lot when paragraphs really only contain <p> tags, <div>s, or extra spaces
     // we filter AFTER generating text models because the generation gets rid of tags that paragraphs can't handle
 
-    // return true if the string contains words,
-    // or if it's a text-model that contains words
-    return _.isString(val) && val.match(/\S/) || _.isString(val.text) && val.text.match(/\S/);
+    // return true if the string contains words (anything that isn't whitespace, but not just a single closing tag),
+    // or if it's a text-model that contains words (anything that isn't whitespace, but not just a single closing tag)
+    return _.isString(val) && val.match(/\S/) && !val.match(/^<\/.*?>$/) || _.isString(val.text) && val.text.match(/\S/) && !val.text.match(/^<\/.*?>$/);
   }).value();
 }
 

--- a/behaviors/wysiwyg.md
+++ b/behaviors/wysiwyg.md
@@ -32,7 +32,8 @@ _Note:_ All pasted text gets run through [text-model](https://github.com/nymag/t
 
 **Paste** is an optional array of pasting rules that's used for parsing and creating different components. This is useful for transforming pasted links into embeds, catching pasted blockquotes, etc. Rules have these properties:
 
-* `match` - regex to match the pasted content. all rules will be wrapped in `^` and `$` (so they don't match urls _inside_ links in the content), as well as `<a>` and `</a>` (so they do match links where the text itself is the url and the link is the only thing in a paragraph)
+* `match` - regex to match the pasted content. all rules will be wrapped in `^` and `$` (so they don't match urls _inside_ links in the content)
+* `matchLink` - boolean to determine whether _links_ containing the regex should also match. Should be true for embeds, false for components that could potentially contain links inside them.
 * `component` - the name of the component that should be created
 * `field` - the name of the field that the captured data should be populated to on the new component. the (last) new component will focus this field after it's added (note: this is limited to a single regex capture group)
 * `group` - (optional) the group that should be focused when the (last) new component is added (instead of the specific field). this is useful for components with forms that contain both the specified field and other things, and preserves the same editing experience as editing that component normally


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/2wVlnmNv/77-bug-pasting-rules-for-multi-line-paragraphs-don-t-work-properly)
* **BREAKING CHANGE:** adds `matchLink` to positively match urls in links (rather than assuming them by default, which broke links inside paragraphs when the WHOLE paragraph was enclosed in a single link)

Updates the component splitting regex:

* split on double `<br>` tags (rather than just one)
* split on `<br>\n`, `\n<br>`, and `\n\n`
* allow whitespace before, after, and between those double line breaks

Cleans the matches:

* removes `<p><br>` at the beginning of strings, not just `<p>` or `<br>`
* removes matches that simply contain a closing tag (it's a google docs edge case)