### PR TITLE
preload schemas server-side

### DIFF
--- a/template.handlebars
+++ b/template.handlebars
@@ -20,7 +20,7 @@
         window.kiln.services.schemaCache = window.kiln.services.schemaCache || {};
 
         {{#each @root._componentSchemas}}
-          window.kiln.services.schemaCache['{{ this.name }}'] = {{{ stringify this.schema }}};
+          window.kiln.services.schemaCache['{{ this.name }}'] = {{{ stringify (yaml (read this.schema)) }}};
         {{/each}}
       </script>
     {{/if}}

--- a/template.handlebars
+++ b/template.handlebars
@@ -11,6 +11,22 @@
       {{/if}}
     </style>
 
+    {{#if @root.locals.edit}}
+      <script>
+        // preload the schemas into the cache
+        // note: this must declare all the levels, since kiln js hasn't loaded yet
+        window.kiln = {
+          services: {
+            schemaCache: {
+              {{#each @root._componentSchemas}}
+                '{{ this.name }}': {{{ stringify this.schema }}},
+              {{/each}}
+            }
+          }
+        }
+      </script>
+    {{/if}}
+
     {{! toolbar }}
     <div class="kiln-toolbar-wrapper">
       <div class="kiln-status"></div>

--- a/template.handlebars
+++ b/template.handlebars
@@ -14,16 +14,14 @@
     {{#if @root.locals.edit}}
       <script>
         // preload the schemas into the cache
-        // note: this must declare all the levels, since kiln js hasn't loaded yet
-        window.kiln = {
-          services: {
-            schemaCache: {
-              {{#each @root._componentSchemas}}
-                '{{ this.name }}': {{{ stringify this.schema }}},
-              {{/each}}
-            }
-          }
-        }
+        // note: this must declare all the levels, since kiln js hasn't loaded yet (but plugins might be loaded)
+        window.kiln = window.kiln || {};
+        window.kiln.services = window.kiln.services || {};
+        window.kiln.services.schemaCache = window.kiln.services.schemaCache || {};
+
+        {{#each @root._componentSchemas}}
+          window.kiln.services.schemaCache['{{ this.name }}'] = {{{ stringify this.schema }}};
+        {{/each}}
       </script>
     {{/if}}
 


### PR DESCRIPTION
* adds schemas of components (currently on the page) to inline js server-side
* uses that exposed schema cache when grabbing new schemas
* note: once we have versioned schemas, we can store this cache in localStorage and get a pretty big performance improvement
* this requires an update to amphora