### PR TITLE
Replace all non word chars for magic button URL

### DIFF
--- a/behaviors/magic-button.js
+++ b/behaviors/magic-button.js
@@ -69,7 +69,7 @@ const _ = require('lodash'),
      * @returns {string}
      */
     formatUrl: function (data, format) {
-      var datafield = toPlainText(data).toLowerCase().replace(/ /g, '-');
+      var datafield = toPlainText(data).toLowerCase().replace(/[^\w]/g, '-').replace(/--+/g, '-');
 
       if (_.isString(format) && !_.isEmpty(format)) {
         return format.replace(/\$DATAFIELD/g, datafield);


### PR DESCRIPTION
When formatting a URL for the magic button, all non-word characters should be replaced by hyphens.