### PR TITLE
fix reloading issue

### DIFF
--- a/services/components/select.js
+++ b/services/components/select.js
@@ -450,11 +450,6 @@ function handler(el, options) {
   var name = references.getComponentNameFromReference(options.ref),
     selector = tpl.get('.component-selector-template');
 
-  // if a component already has a selector, don't add another
-  if (_.find(el.children, (child) => child.classList.contains('component-selector'))) {
-    return Promise.resolve(el);
-  }
-
   // resolve parent info. if there are no parents this resolves to empty object
   return getParentInfo(el).then(function (parent) {
     // add options to the component selector

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -107,6 +107,15 @@ function save(data) {
     if (validationErrors.length) {
       throw new Error(validationErrors);
     } else {
+      let el = dom.find(`[data-uri="${uri}"]`);
+
+      // todo: this is a short term fix for the "double-reloading" issue caused by
+      // the fact that queued items may resolve more than once (which causes the components to be reloaded more than once)
+      // a class is added to components when they're reloaded, which we explicitly REMOVE right before they get saved
+      if (el) {
+        el.classList.remove('kiln-handlers-added');
+      }
+
       return cache.saveForHTML(data)
         .then(function (savedData) {
           window.kiln.trigger('save', data);


### PR DESCRIPTION
this moves the fix I did for `select.handler` up to the `reload` service, and makes it more consistent. This prevents components from getting double selectors/placeholders/events/etc if they are saved with queued PUTs that have been cached.

Right now it just sets a class on the component (which works, but is kinda gross). The full fix would be to refactor the `reload` stuff _into_ the queue, so instead of just queueing api calls it would queue the _whole_ component save + re-render process.