### PR TITLE
Ensures clicking pane does not trigger page component click handler

### DIFF
--- a/controllers/pane.js
+++ b/controllers/pane.js
@@ -79,6 +79,7 @@ module.exports = function () {
     close: function (e) {
       var el = this.el;
 
+      e.stopPropagation();
       if (e.target === e.currentTarget || e.currentTarget.classList.contains('close')) {
         // we clicked on the overlay itself
         dom.removeElement(el);


### PR DESCRIPTION
This relates to the second issue described in [this Ticket](https://trello.com/c/KX9yJXVa/1374-fix-broken-clay-space-edit) — clicking the settings icon for clay-space-logic is opening the settings form for that logic instance, but that form closes almost instantly.

Here's what seems to be happening:
* Kiln attaches to each component a click listener that closes all forms. This includes the page component — the HTML element itself.
* A click event on a pane bubbles up to the HTML element, triggering the open form to close.
* To prevent this, I've added `e.stopPropagation()` to the listener of pane, preventing it from triggering listeners up the DOM tree.