### PR TITLE
preload data

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "moment": "^2.10.6",
     "node-sass": "^4.3.0",
     "nprogress": "^0.2.0",
-    "nymag-handlebars": "^1.8.1",
+    "nymag-handlebars": "^1.8.2",
     "postcss-loader": "^1.2.2",
     "promise-queue": "^2.2.3",
     "promise-timeout": "^1.0.0",

--- a/services/edit/cache.js
+++ b/services/edit/cache.js
@@ -203,7 +203,8 @@ function preloadData(tree) {
 
   if (_.isObject(tree)) {
     _.forOwn(tree, function (val, key) {
-      if (!_.includes(key, '_')) {
+      if (!_.includes(key, '_') && !_.includes(['blockParams', 'filename', 'knownHelpers', 'locals', 'media', 'site', 'state', 'template'])) {
+        // don't iterate through any of the templating/amphora metadata or locals/state
         preloadData(val);
       }
     });

--- a/services/edit/cache.js
+++ b/services/edit/cache.js
@@ -190,6 +190,28 @@ function createThrough(uri, data) {
   });
 }
 
+/**
+ * preload data for components on the page
+ * this iterates through a tree of data and warms the getDataOnly cache for all components found
+ * @param  {*} tree
+ */
+function preloadData(tree) {
+  if (_.isObject(tree) && tree._ref) {
+    // warm cache if we found a component!
+    exports.getDataOnly.cache.set(tree._ref, tree);
+  }
+
+  if (_.isObject(tree)) {
+    _.forOwn(tree, function (val, key) {
+      if (!_.includes(key, '_')) {
+        preloadData(val);
+      }
+    });
+  } else if (_.isArray(tree)) {
+    _.each(tree, preloadData);
+  }
+}
+
 // remembers
 exports.getData = control.memoizePromise(getData);
 exports.getDataOnly = control.memoizePromise(getDataOnly);
@@ -208,3 +230,8 @@ exports.clearSchemaCache = function () {
 exports.removeExtras = removeExtras; // testing client-side models
 
 _.set(window, 'kiln.services.schemaCache', schemaCache);
+
+// preload data on page load
+if (window.kiln.services.preloadData) {
+  preloadData(window.kiln.services.preloadData);
+}

--- a/template.handlebars
+++ b/template.handlebars
@@ -26,6 +26,8 @@
         // add objects for models and templates (injected through resolveMedia)
         window.kiln.services.componentModels = window.kiln.services.componentModels || {};
         window.kiln.services.componentTemplates = window.kiln.services.componentTemplates || {};
+
+        window.kiln.services.preloadData = {{{ stringify @root }}};
       </script>
     {{/if}}
 

--- a/template.handlebars
+++ b/template.handlebars
@@ -27,7 +27,7 @@
         window.kiln.services.componentModels = window.kiln.services.componentModels || {};
         window.kiln.services.componentTemplates = window.kiln.services.componentTemplates || {};
 
-        window.kiln.services.preloadData = {{{ stringify @root }}};
+        window.kiln.services.preloadData = {{{ default (stringify @root) '{}' }}};
       </script>
     {{/if}}
 


### PR DESCRIPTION
* warms the `cache.getDataOnly` cache for all components currently on the page when it loads
* this eliminates the onload API calls for everything except the page itself and the layout itself (since the page API call isn't cached, and the layout data can't be easily gleaned from the tree)