### PR TITLE
add partials for all component templates

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,6 @@ const files = [
           loader: 'babel-loader',
           options: {
             presets: ['es2015'],
-            cacheDirectory: true,
             plugins: [['istanbul', {
               exclude: [
                 '**/*.test.js',

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -18,11 +18,15 @@ var _ = require('lodash'),
   hbs = require('nymag-handlebars')(),
   pt = require('promise-timeout');
 
+// add precompiled templates as partials (on page load)
 document.addEventListener('DOMContentLoaded', function () {
-  // add precompiled templates as partials (on page load)
-  _.forOwn(window.kiln.services.componentTemplates, function (tpl, name) {
-    hbs.registerPartial(name, hbs.template(tpl));
-  });
+  const templates = _.get(window, 'kiln.services.componentTemplates');
+
+  if (_.isObject(templates) && !_.isEmpty(templates)) {
+    _.forOwn(templates, function (tpl, name) {
+      hbs.registerPartial(name, hbs.template(tpl));
+    });
+  }
 });
 
 /**

--- a/services/edit/index.js
+++ b/services/edit/index.js
@@ -18,6 +18,13 @@ var _ = require('lodash'),
   hbs = require('nymag-handlebars')(),
   pt = require('promise-timeout');
 
+document.addEventListener('DOMContentLoaded', function () {
+  // add precompiled templates as partials (on page load)
+  _.forOwn(window.kiln.services.componentTemplates, function (tpl, name) {
+    hbs.registerPartial(name, hbs.template(tpl));
+  });
+});
+
 /**
  * Cloning removes extra properties like _schema from standard types like Array, because we're doing a bad thing.
  *


### PR DESCRIPTION
* register partials using the precompiled templates on load
* this allows components to embed other components completely client-side