### PR TITLE
Patch datetime local input

### DIFF
--- a/behaviors/text.js
+++ b/behaviors/text.js
@@ -24,8 +24,8 @@ var dom = require('@nymag/dom'),
     'number',
     'range'
   ],
-  firefoxDateFormat = 'YYYY-MM-DD hh:mm A',
-  defaultDateFormat = 'YYYY-MM-DDThh:mm';
+  firefoxDateFormat = 'YYYY-MM-DD HH:mm A',
+  defaultDateFormat = 'YYYY-MM-DDTHH:mm';
 
 /**
  * get attribute value of boolean fields


### PR DESCRIPTION
### Patch datetime-local input visual update

Fixes bug with text behavior.

## Steps to reproduce the bug:
- Set an editable field in the schema.yml for a
component to be of type `datetime-local`
- In Kiln, edit the date, setting it to be PM
- Edit another part of the date (not AM/PM)
Observed result: the input instantly reverts
to AM.

## Cause and solution

format string should have been
`YYYY-MM-DDTHH:mm`
    
Incorrect format string was causing
the UI to never show "PM" even when
the data was correct.
