### PR TITLE
Vue paste fix

### DIFF
--- a/behaviors/wysiwyg.vue
+++ b/behaviors/wysiwyg.vue
@@ -634,6 +634,7 @@
           let [elementMatchers, textMatchers] = this.prepareMatching(),
             sanitized, delta, components;
 
+
           if (_.isString(html)) {
             this.container.innerHTML = html;
           }
@@ -653,7 +654,9 @@
             // asynchronously trigger component creation if they match things
             // note: this may also replace the current paragraph if the entirety of the paragraph
             // is something that matches another component
-            components = matchComponents(splitParagraphs(sanitizeBlockHTML(this.container.innerHTML)), rules);
+            if (rules && rules.length) {
+              components = matchComponents(splitParagraphs(sanitizeBlockHTML(this.container.innerHTML)), rules);
+            }
             delta = handleMultiParagraphPaste(components, {
               quill: this.quill,
               current,

--- a/behaviors/wysiwyg.vue
+++ b/behaviors/wysiwyg.vue
@@ -634,7 +634,6 @@
           let [elementMatchers, textMatchers] = this.prepareMatching(),
             sanitized, delta, components;
 
-
           if (_.isString(html)) {
             this.container.innerHTML = html;
           }


### PR DESCRIPTION
Problem: Kiln errors if the user edits multi-component WYSIWYG fields with no paste rules (see: disclaimer-text). The component does not update as expected.

```
cj0txz41c00007u1o29hfqkoz.html?edit=true:4361 Error: No matching paste rule for asdfasdf<br />
    at cj0txz41c00007u1o29hfqkoz.html?edit=true:61408
    at arrayMap (cj0txz41c00007u1o29hfqkoz.html?edit=true:12134)
    at map (cj0txz41c00007u1o29hfqkoz.html?edit=true:2540)
    at matchComponents (cj0txz41c00007u1o29hfqkoz.html?edit=true:61384)
    at ClayClipboard.convert (cj0txz41c00007u1o29hfqkoz.html?edit=true:61780)
    at new Quill (cj0txz41c00007u1o29hfqkoz.html?edit=true:73343)
    at VueComponent.mounted (cj0txz41c00007u1o29hfqkoz.html?edit=true:61918)
    at callHook (cj0txz41c00007u1o29hfqkoz.html?edit=true:5187)
    at Object.insert (cj0txz41c00007u1o29hfqkoz.html?edit=true:5866)
    at invokeInsertHook (cj0txz41c00007u1o29hfqkoz.html?edit=true:7872)
```

Solution: Check that paste rules exist before applying any.