### PR TITLE
Cache lists in Vuex store

### DIFF
--- a/lib/core-data/amphora-api.js
+++ b/lib/core-data/amphora-api.js
@@ -1,0 +1,18 @@
+import { getJSON } from './api';
+import { uriToUrl } from '../utils/urls';
+
+const TEXT_PROP = 'text';
+
+function flattenText(items) {
+  const pluckedText = _.compact(_.map(items, TEXT_PROP)),
+    hasTextProp = _.isString(_.head(pluckedText));
+
+  return hasTextProp ? pluckedText : items;
+}
+
+export function getList(prefix, listName) {
+  const uri = uriToUrl(prefix + '/lists/' + listName);
+
+  return getJSON(uri)
+    .then(flattenText);
+}

--- a/lib/core-data/store.js
+++ b/lib/core-data/store.js
@@ -5,6 +5,7 @@ import defaultState from '../preloader/default-state';
 import mutations from './mutations';
 import actions from './actions';
 import plugins from './plugins';
+import lists from '../lists';
 
 Vue.use(Vuex);
 Vue.use(AsyncComputed);
@@ -14,7 +15,10 @@ const store = new Vuex.Store({
   state: defaultState,
   mutations: mutations,
   actions: actions,
-  plugins: plugins
+  plugins: plugins,
+  modules: {
+    lists
+  }
 });
 
 export default store;

--- a/lib/lists/actions.js
+++ b/lib/lists/actions.js
@@ -13,12 +13,12 @@ import {
  * @param {object} payload
  * @returns {Promise}
  */
-function getList(store, {prefix, listName}) {
+const getList = (store, {prefix, listName}, getListFunction = getListFromAmphora) => {
   store.commit(LIST_LOAD_PENDING, {listName});
-  getListFromAmphora(prefix, listName)
+  return getListFunction(prefix, listName)
           .then(listItems => store.commit(LIST_LOAD_SUCCESS, {listItems, listName}))
           .catch(error => store.commit(LIST_LOAD_FAIL, {listName, error}));
-}
+};
 
 
 export default {

--- a/lib/lists/actions.js
+++ b/lib/lists/actions.js
@@ -1,0 +1,26 @@
+import {
+  LIST_LOAD_PENDING,
+  LIST_LOAD_SUCCESS,
+  LIST_LOAD_FAIL
+} from './mutationTypes';
+import {
+  getList as getListFromAmphora
+} from '../core-data/amphora-api';
+
+/**
+ * @param {object} store
+ * @param {object} state
+ * @param {object} payload
+ * @returns {Promise}
+ */
+function getList(store, {prefix, listName}) {
+  store.commit(LIST_LOAD_PENDING, {listName});
+  getListFromAmphora(prefix, listName)
+          .then(listItems => store.commit(LIST_LOAD_SUCCESS, {listItems, listName}))
+          .catch(error => store.commit(LIST_LOAD_FAIL, {listName, error}));
+}
+
+
+export default {
+  getList
+};

--- a/lib/lists/actions.test.js
+++ b/lib/lists/actions.test.js
@@ -1,0 +1,52 @@
+import actions from './actions';
+import {
+  LIST_LOAD_PENDING,
+  LIST_LOAD_SUCCESS,
+  LIST_LOAD_FAIL
+} from './mutationTypes';
+
+describe('list actions', () => {
+
+  describe('getList', () => {
+
+    const prefix = 'prefix',
+      listName = 'listName',
+      pendingPayload = {listName},
+      successPayload = {listName, listItems: ['item1', 'item2']};
+
+    it('can pend, then succeed', () => {
+      const store = {
+          commit: sinon.spy()
+        },
+        getListFromAmphora = sinon.spy(() => Promise.resolve(successPayload.listItems));
+
+      return actions.getList(store, {prefix, listName}, getListFromAmphora)
+        .then(() => {
+          expect(getListFromAmphora).to.have.been.calledWith(prefix, listName);
+          const commits = store.commit.getCalls();
+
+          expect(commits[0].args).to.deep.eql([LIST_LOAD_PENDING, pendingPayload]);
+          expect(commits[1].args).to.deep.eql([LIST_LOAD_SUCCESS, successPayload]);
+        });
+    });
+
+    it('can pend, then fail', () => {
+      const store = {
+          commit: sinon.spy()
+        },
+        error = new Error('error'),
+        pendingPayload = {listName},
+        errorPayload = {listName, error},
+        getListFromAmphora = sinon.spy(() => Promise.reject(errorPayload));
+
+      return actions.getList(store, {prefix, listName}, getListFromAmphora)
+        .then(() => {
+          const commits = store.commit.getCalls();
+          
+          expect(commits[0].args).to.deep.eql([LIST_LOAD_PENDING, pendingPayload]);
+          expect(commits[1].args[0]).to.deep.eql(LIST_LOAD_FAIL);
+        });
+    });
+
+  });
+});

--- a/lib/lists/index.js
+++ b/lib/lists/index.js
@@ -1,0 +1,11 @@
+import mutations from './mutations';
+import actions from './actions';
+
+// Vuex module
+const store = {
+  state: {},
+  mutations,
+  actions
+};
+
+export default store;

--- a/lib/lists/mutationTypes.js
+++ b/lib/lists/mutationTypes.js
@@ -1,0 +1,4 @@
+/* eslint-disable one-var */
+export const LIST_LOAD_PENDING = 'LIST_LOAD_PENDING';
+export const LIST_LOAD_SUCCESS = 'LIST_LOAD_SUCCESS';
+export const LIST_LOAD_FAIL = 'LIST_LOAD_FAIL';

--- a/lib/lists/mutations.js
+++ b/lib/lists/mutations.js
@@ -16,7 +16,7 @@ export default {
   },
   [LIST_LOAD_SUCCESS]: (state, {listName, listItems}) => {
     Vue.set(state, listName, {
-      isLoading: true,
+      isLoading: false,
       error: null,
       items: listItems
     });

--- a/lib/lists/mutations.js
+++ b/lib/lists/mutations.js
@@ -1,0 +1,36 @@
+import Vue from 'vue';
+import {
+  LIST_LOAD_PENDING,
+  LIST_LOAD_SUCCESS,
+  LIST_LOAD_FAIL
+} from './mutationTypes';
+
+export default {
+  [LIST_LOAD_PENDING]: (state, {listName}) => {
+    Vue.set(state, listName, {
+      isLoading: true,
+      error: null,
+      items: []
+    });
+    return state;
+  },
+  [LIST_LOAD_SUCCESS]: (state, {listName, listItems}) => {
+    Vue.set(state, listName, {
+      isLoading: true,
+      error: null,
+      items: listItems
+    });
+    return state;
+  },
+  [LIST_LOAD_FAIL]: (state, {listName, error}) => {
+    Vue.set(state, listName, {
+      isLoading: false,
+      error: {
+        object: error,
+        message: error.message
+      },
+      items: []
+    });
+    return state;
+  }
+};

--- a/lib/lists/mutations.test.js
+++ b/lib/lists/mutations.test.js
@@ -1,0 +1,74 @@
+import mutations from './mutations';
+import {
+    LIST_LOAD_PENDING,
+    LIST_LOAD_SUCCESS,
+    LIST_LOAD_FAIL
+} from './mutationTypes';
+
+describe('list mutations', () => {
+  it('handles PENDING', () => {
+    const listName = 'fooList',
+      otherList = {
+        isLoading: false,
+        error: null,
+        items: []
+      };
+
+    expect(
+      mutations[LIST_LOAD_PENDING]({}, {listName})
+    ).to.deep.eql({
+      fooList: {
+        isLoading: true,
+        error: null,
+        items: []
+      }
+    });
+
+    expect(
+      mutations[LIST_LOAD_PENDING]({otherList}, {listName})
+    ).to.deep.eql({
+      otherList,
+      fooList: {
+        isLoading: true,
+        error: null,
+        items: []
+      }
+    });
+  });
+
+  it('handles SUCCESS', () => {
+    const listName = 'fooList',
+      listItems = ['itemA', 'itemB'];
+
+    expect(
+      mutations[LIST_LOAD_SUCCESS]({}, {listName, listItems})
+    ).to.deep.eql({
+      [listName]: {
+        isLoading: false,
+        error: null,
+        items: listItems
+      }
+    });
+  });
+
+  it('handles FAIL', () => {
+    const listName = 'fooList',
+      error = new Error('something went wrong');
+
+    expect(
+      mutations[LIST_LOAD_FAIL]({}, {listName, error})
+    ).to.deep.eql({
+      [listName]: {
+        isLoading: false,
+        error: {
+          object: error,
+          message: error.message
+        },
+        items: []
+      }
+    });
+  });
+
+
+
+});

--- a/lib/preloader/default-state.js
+++ b/lib/preloader/default-state.js
@@ -7,12 +7,6 @@ export default {
     data: {}, // page data
     state: {} // scheduled, published, etc
   },
-  // data for lists
-  lists: {
-    users: [],
-    'new-pages': []
-  },
-  // data for logged-in user
   user: {},
   // ui state management
   ui: {


### PR DESCRIPTION
Instead of requesting list data from Amphora each time an
autocomplete behavior needs it, check to see if it is in the Vuex
store, and get it from the Vuex store if available.
If it's not available, dispatch an action which causes the lists
to be fetched.

Track pending/success/failure state of the lists request. Not
doing anything with it yet, but it's there if we want to reflect
this state in the UI or use Vue devtools to see what's happening.

Doesn't buy us much beyond cleanliness, since the browser will
probably cache the results of the Amphora calls anyway, but
it's a little cleaner to keep stuff in the store.

In this commit, I also added the first module to the Vuex store.
Seems like an easier way to divide up the Vuex stuff, and is
similar to `combineReducers` in Redux.

I deleted the existing `lists` stuff in the store so as not to
have name conflicts. As far as I can tell, that stuff wasn't used.

This is prep work for a change I hope to make in another PR: adding an argument to the `simple-list` and `test` behaviors so that we can validate that the user's entry is a member of the given list.