### PR TITLE
Expose store

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -65,6 +65,7 @@ Vue.directive('h-scroll', hScrollDirective());
 window.kiln = window.kiln || {};
 // .plugins, .behaviors, .validators, and .panes objects should already exist
 window.kiln.utils = utilsAPI;
+window.kiln.store = store;
 
 // kick off loading when DOM is ready
 // note: preloaded data, external behaviors, decorators, and validation rules should already be added


### PR DESCRIPTION
- Expose Vuex store on `kiln` object

Expose the Vuex store so plugins and components can subscribe
to changes.

In particular, I think this may be needed for clay-space-edit.

Definitely open to suggestions if there is a better way of getting access to the store!