### PR TITLE
Fix clientSave to save new object returned by model

### DIFF
--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -41,7 +41,7 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
     .catch((e) => logSaveError(uri, e, store))
     .then((savedData) => {
       // kick api call off in the background
-      addToQueue(save, [uri, data, false]) // add hooks=false to prevent models from re-running on server
+      addToQueue(save, [uri, savedData, false]) // add hooks=false to prevent models from re-running on server
         // note: we don't care about the data we got back from the api
         .catch((e) => {
           store.commit(REVERT_COMPONENT, {uri, oldData});


### PR DESCRIPTION
Currently, `clientSave` is returning the object that is passed into a model.save fnc instead of whatever object that fnc returns/resolves. As a result, a model save fnc that returns/resolves a new object instead of simply mutating the existing object will not work as expected. This PR fixes this bug. ([Discovered in work related to this Trello](https://trello.com/c/nEvvCuZN/105-imgur))