### PR TITLE
reveal and conditional-required

### DIFF
--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -200,6 +200,33 @@ Appends "required" to a field's label, to mark that field as required.
 
 _No arguments_
 
+# reveal
+
+Conditionally shows/hides a field based on another field
+
+## Arguments
+
+* **field** to compare against
+* **operator** _(optional)_ to use for the comparison
+* **value** _(optional)_ to compare the field against
+
+If neither `operator` nor `value` are specified, this will show the current field if the compared field has any data (i.e. if it's not empty). If only the value is specified, it'll default to strict equality.
+
+Operators:
+
+* `===`
+* `!==`
+* `<`
+* `>`
+* `<=`
+* `>=`
+* `typeof`
+* `regex`
+* `empty` (only checks field data, no value needed)
+* `not-empty` (only checks field data, no value needed)
+* `truthy` (only checks field data, no value needed)
+* `falsy` (only checks field data, no value needed)
+
 # segmented-button
 
 A group of buttons allowing the user to select one of a few related options. Functions like a styled radio button.

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -58,6 +58,33 @@ The mode of the editor sets syntax highlighting, linting, and other functionalit
 
 _Note:_ We will add more supported modes as we find use cases for them. See [this link](http://codemirror.net/mode/) for the full list of modes supported in codemirror.
 
+# required
+
+Appends "required (field name)" to a field's label, to mark that field as required (based on another field).
+
+## Arguments
+
+* **field** to compare against
+* **operator** _(optional)_ to use for the comparison
+* **value** _(optional)_ to compare the field against
+
+If neither `operator` nor `value` are specified, this will make the current field required if the compared field has any data (i.e. if it's not empty). If only the value is specified, it'll default to strict equality.
+
+Operators:
+
+* `===`
+* `!==`
+* `<`
+* `>`
+* `<=`
+* `>=`
+* `typeof`
+* `regex`
+* `empty` (only checks field data, no value needed)
+* `not-empty` (only checks field data, no value needed)
+* `truthy` (only checks field data, no value needed)
+* `falsy` (only checks field data, no value needed)
+
 # description
 
 Appends a description to a field.

--- a/behaviors/conditional-required.vue
+++ b/behaviors/conditional-required.vue
@@ -40,7 +40,7 @@
 
 <template>
   <transition name="fade">
-    <span v-if="hasLabel && isRequired" class="label-conditional-required">required ({{ fieldLabel }})</span>
+    <span v-if="hasLabel && isRequired" class="label-conditional-required">required (based on {{ fieldLabel }})</span>
   </transition>
 </template>
 
@@ -48,7 +48,7 @@
   import _ from 'lodash';
   import { fieldProp, behaviorKey } from '../lib/utils/references';
   import { expand, convertNativeTagName } from '../lib/forms/behaviors';
-  import { getSchema } from '../lib/core-data/components';
+  import { getSchema, getData } from '../lib/core-data/components';
   import { compare } from '../lib/utils/comparators';
   import label from '../lib/utils/label';
 
@@ -65,7 +65,11 @@
         const field = this.args.field,
           operator = this.args.operator,
           value = this.args.value,
-          data = _.get(this.$store, `state.ui.currentForm.fields[${field}]`);
+          // compare against the field if it's in the current form,
+          // but fall back to comparing against data in the component
+          // (this allows comparing to fields that might not be in the same form)
+          uri = _.get(this.$store, 'state.ui.currentForm.uri'),
+          data = _.get(this.$store, `state.ui.currentForm.fields[${field}]`) || getData(uri, field);
 
         return compare({ data, operator, value });
       },

--- a/behaviors/conditional-required.vue
+++ b/behaviors/conditional-required.vue
@@ -1,0 +1,80 @@
+<docs>
+  # required
+
+  Appends "required (field name)" to a field's label, to mark that field as required (based on another field).
+
+  ## Arguments
+
+  * **field** to compare against
+  * **operator** _(optional)_ to use for the comparison
+  * **value** _(optional)_ to compare the field against
+
+  If neither `operator` nor `value` are specified, this will make the current field required if the compared field has any data (i.e. if it's not empty). If only the value is specified, it'll default to strict equality.
+
+  Operators:
+
+  * `===`
+  * `!==`
+  * `<`
+  * `>`
+  * `<=`
+  * `>=`
+  * `typeof`
+  * `regex`
+  * `empty` (only checks field data, no value needed)
+  * `not-empty` (only checks field data, no value needed)
+  * `truthy` (only checks field data, no value needed)
+  * `falsy` (only checks field data, no value needed)
+</docs>
+
+<style lang="sass">
+  @import '../styleguide/colors';
+  @import '../styleguide/typography';
+
+  .label-conditional-required {
+    @include tertiary-text();
+
+    color: $behavior-required;
+  }
+</style>
+
+<template>
+  <transition name="fade">
+    <span v-if="hasLabel && isRequired" class="label-conditional-required">required ({{ fieldLabel }})</span>
+  </transition>
+</template>
+
+<script>
+  import _ from 'lodash';
+  import { fieldProp, behaviorKey } from '../lib/utils/references';
+  import { expand, convertNativeTagName } from '../lib/forms/behaviors';
+  import { getSchema } from '../lib/core-data/components';
+  import { compare } from '../lib/utils/comparators';
+  import label from '../lib/utils/label';
+
+  export default {
+    props: ['name', 'data', 'schema', 'args'],
+    data() {
+      return {};
+    },
+    computed: {
+      hasLabel() {
+        return !!_.find(expand(this.schema[fieldProp]), (b) => b[behaviorKey] === convertNativeTagName('label'));
+      },
+      isRequired() {
+        const field = this.args.field,
+          operator = this.args.operator,
+          value = this.args.value,
+          data = _.get(this.$store, `state.ui.currentForm.fields[${field}]`);
+
+        return compare({ data, operator, value });
+      },
+      fieldLabel() {
+        const field = this.args.field;
+
+        return label(field, getSchema(_.get(this.$store, 'state.ui.currentForm.uri'), field));
+      }
+    },
+    slot: 'before'
+  };
+</script>

--- a/behaviors/reveal.vue
+++ b/behaviors/reveal.vue
@@ -1,0 +1,80 @@
+<docs>
+  # reveal
+
+  Conditionally shows/hides a field based on another field
+
+  ## Arguments
+
+  * **field** to compare against
+  * **operator** _(optional)_ to use for the comparison
+  * **value** _(optional)_ to compare the field against
+
+  If neither `operator` nor `value` are specified, this will show the current field if the compared field has any data (i.e. if it's not empty). If only the value is specified, it'll default to strict equality.
+
+  Operators:
+
+  * `===`
+  * `!==`
+  * `<`
+  * `>`
+  * `<=`
+  * `>=`
+  * `typeof`
+  * `regex`
+  * `empty` (only checks field data, no value needed)
+  * `not-empty` (only checks field data, no value needed)
+  * `truthy` (only checks field data, no value needed)
+  * `falsy` (only checks field data, no value needed)
+</docs>
+
+<style lang="sass">
+
+</style>
+
+<template>
+  <span class="kiln-hide"></span>
+</template>
+
+<script>
+  import _ from 'lodash';
+  import { getField } from '../lib/forms/field-helpers';
+  import { compare } from '../lib/utils/comparators';
+
+  export default {
+    props: ['name', 'data', 'schema', 'args'],
+    data() {
+      return {};
+    },
+    computed: {
+      isShown() {
+        const field = this.args.field,
+          operator = this.args.operator,
+          value = this.args.value,
+          data = _.get(this.$store, `state.ui.currentForm.fields[${field}]`);
+
+        return compare({ data, operator, value });
+      }
+    },
+    watch: {
+      isShown(val) {
+        const fieldEl = getField(this.$el);
+
+        if (val) {
+          fieldEl.classList.remove('kiln-reveal-hide');
+        } else {
+          fieldEl.classList.add('kiln-reveal-hide');
+        }
+      }
+    },
+    mounted() {
+      const fieldEl = getField(this.$el);
+
+      if (this.isShown) {
+        fieldEl.classList.remove('kiln-reveal-hide');
+      } else {
+        fieldEl.classList.add('kiln-reveal-hide');
+      }
+    },
+    slot: 'after'
+  };
+</script>

--- a/behaviors/reveal.vue
+++ b/behaviors/reveal.vue
@@ -40,6 +40,19 @@
   import { getField } from '../lib/forms/field-helpers';
   import { compare } from '../lib/utils/comparators';
 
+  /**
+   * toggle showing or hiding a field
+   * @param  {Element}  fieldEl
+   * @param  {Boolean} isShown
+   */
+  function toggleField(fieldEl, isShown) {
+    if (isShown) {
+      fieldEl.classList.remove('kiln-reveal-hide');
+    } else {
+      fieldEl.classList.add('kiln-reveal-hide');
+    }
+  }
+
   export default {
     props: ['name', 'data', 'schema', 'args'],
     data() {
@@ -57,23 +70,11 @@
     },
     watch: {
       isShown(val) {
-        const fieldEl = getField(this.$el);
-
-        if (val) {
-          fieldEl.classList.remove('kiln-reveal-hide');
-        } else {
-          fieldEl.classList.add('kiln-reveal-hide');
-        }
+        toggleField(getField(this.$el), val);
       }
     },
     mounted() {
-      const fieldEl = getField(this.$el);
-
-      if (this.isShown) {
-        fieldEl.classList.remove('kiln-reveal-hide');
-      } else {
-        fieldEl.classList.add('kiln-reveal-hide');
-      }
+      toggleField(getField(this.$el), this.isShown);
     },
     slot: 'after'
   };

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -3,12 +3,21 @@ import { closest, find } from '@nymag/dom';
 import { fieldClass, mainBehaviorClass, firstFieldClass } from '../utils/references';
 
 /**
+ * find the field element a behavior is inside
+ * @param  {Element} el
+ * @return {Element}
+ */
+export function getField(el) {
+  return closest(el, `.${fieldClass}`);
+}
+
+/**
  * find main input of a field
  * @param  {element} el
  * @return {Element|null}
  */
 export function getInput(el) {
-  const field = closest(el, `.${fieldClass}`),
+  const field = getField(el),
     main = field && find(field, `.${mainBehaviorClass}`);
 
   return main && (find(main, 'input') || find(main, 'textarea') || find(main, '.wysiwyg-input'));
@@ -21,7 +30,7 @@ export function getInput(el) {
  * @return {Boolean}
  */
 export function isFirstField(el) {
-  const field = closest(el, `.${fieldClass}`);
+  const field = getField(el);
 
   return field && field.classList.contains(firstFieldClass);
 }

--- a/lib/forms/field.vue
+++ b/lib/forms/field.vue
@@ -3,6 +3,19 @@
 
   .kiln-field {
     @include field();
+
+    opacity: 1;
+    transition: opacity 300ms linear;
+    visibility: visible;
+
+    &.kiln-reveal-hide {
+      // fade out, THEN remove the element from the space it takes up
+      // (by using margin-top, which can be transitioned and thus delayed)
+      margin-top: -1000px;
+      opacity: 0;
+      transition: visibility 0ms 300ms, margin-top 0ms 300ms, opacity 300ms linear;
+      visibility: hidden;
+    }
   }
 
   .editor-inline {
@@ -13,7 +26,7 @@
 </style>
 
 <template>
-  <fieldset class="kiln-field" v-if="beforeBehaviors.lenght || mainBehaviors.length || afterBehaviors.length">
+  <fieldset class="kiln-field" v-if="beforeBehaviors.length || mainBehaviors.length || afterBehaviors.length">
     <div class="field-before">
       <component v-for="behavior in beforeBehaviors" :is="behavior.fn" :name="name" :data="data" :schema="schema" :args="behavior.args"></component>
     </div>

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -8,7 +8,7 @@ const operators = {
   '<=': (l, r) => l <= r,
   '>=': (l, r) => l >= r,
   typeof: (l, r) => typeof l == r,
-  regex: (l, r) => (new RegExp(r)).exec(l),
+  regex: (l, r) => !!(new RegExp(r)).exec(l),
   empty: (l) => isEmpty(l),
   'not-empty': (l) => !isEmpty(l),
   truthy: (l) => !!l,

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 const operators = {
   '===': (l, r) => l === r,
   '!==': (l, r) => l !== r,

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -1,0 +1,54 @@
+const operators = {
+  '===': (l, r) => l === r,
+  '!==': (l, r) => l !== r,
+  '<': (l, r) => l < r,
+  '>': (l, r) => l > r,
+  '<=': (l, r) => l <= r,
+  '>=': (l, r) => l >= r,
+  typeof: (l, r) => typeof l == r,
+  regex: (l, r) => (new RegExp(r)).exec(l),
+  empty: (l) => isEmpty(l),
+  'not-empty': (l) => !isEmpty(l),
+  truthy: (l) => !!l,
+  falsy: (l) => !!!l
+};
+
+/**
+ * determine if a field is empty
+ * @param  {*}  val
+ * @return {Boolean}
+ */
+export function isEmpty(val) {
+  if (_.isArray(val) || _.isObject(val)) {
+    return _.isEmpty(val);
+  } else if (_.isString(val)) {
+    return val.length === 0; // emptystring is empty
+  } else if (_.isNull(val) || _.isUndefined(val)) {
+    return true; // null and undefined are empty
+  } else {
+    // numbers, booleans, etc are never empty
+    return false;
+  }
+}
+
+/**
+ * compare a field's data to a value
+ * @param  {*} data from a field
+ * @param  {string} [operator]
+ * @param  {*} [value]
+ * @return {boolean}
+ */
+export function compare({ data, operator, value }) {
+  if (!operator && value === undefined) {
+    // if neither operator or value are specified, default to
+    // checking if field has a value
+    return !isEmpty(data);
+  } else if (!operator) {
+    // if no operator, default to equal
+    return operators['==='](data, value);
+  } else if (operators[operator]) {
+    return operators[operator](data, value);
+  } else {
+    throw new Error(`Unknown operator: ${operator}`);
+  }
+}

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -1,0 +1,56 @@
+import * as lib from './comparators';
+
+describe('comparators', () => {
+  describe('isEmpty', () => {
+    const fn = lib.isEmpty;
+
+    it('returns false if non-empty string', () => expect(fn('hi')).to.equal(false));
+    it('returns false if any number', () => expect(fn(0)).to.equal(false));
+    it('returns false if any boolean', () => expect(fn(false)).to.equal(false));
+    it('returns true if empty string', () => expect(fn('')).to.equal(true));
+    it('returns true if null', () => expect(fn(null)).to.equal(true));
+    it('returns true if undefined', () => expect(fn('')).to.equal(true));
+    it('returns true if empty array', () => expect(fn([])).to.equal(true));
+    it('returns true if empty object', () => expect(fn({})).to.equal(true));
+  });
+
+  describe('compare', () => {
+    const fn = lib.compare;
+
+    it('throws error if unknown operator', () => expect(() => fn({ operator: 'asdf' })).to.throw(Error));
+
+    it('defaults to checking if field has value', () => {
+      expect(fn({data: 'hi'})).to.equal(true);
+      expect(fn({data: ''})).to.equal(false);
+    });
+
+    it('defaults to using the equal operator', () => {
+      expect(fn({data: 1, value: 1})).to.equal(true);
+      expect(fn({data: 1, value: 0})).to.equal(false);
+    });
+
+    it('compares equality', () => {
+      expect(fn({data: 1, operator: '===', value: 1})).to.equal(true);
+      expect(fn({data: 1, operator: '!==', value: 0})).to.equal(true);
+    });
+
+    it('compares range', () => {
+      expect(fn({data: 1, operator: '<', value: 2})).to.equal(true);
+      expect(fn({data: 1, operator: '>', value: 0})).to.equal(true);
+      expect(fn({data: 1, operator: '<=', value: 1})).to.equal(true);
+      expect(fn({data: 1, operator: '>=', value: 1})).to.equal(true);
+    });
+
+    it('compares typeof', () => expect(fn({data: 'hi', operator: 'typeof', value: 'string'})).to.equal(true));
+
+    it('compares field emptiness', () => {
+      expect(fn({data: [], operator: 'empty'})).to.equal(true);
+      expect(fn({data: false, operator: 'not-empty'})).to.equal(true);
+    });
+
+    it('compares field truthiness', () => {
+      expect(fn({data: [], operator: 'truthy'})).to.equal(true);
+      expect(fn({data: false, operator: 'falsy'})).to.equal(true);
+    });
+  });
+});

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -43,6 +43,11 @@ describe('comparators', () => {
 
     it('compares typeof', () => expect(fn({data: 'hi', operator: 'typeof', value: 'string'})).to.equal(true));
 
+    it('compares regex', () => {
+      expect(fn({data: 'hello', operator: 'regex', value: '^hel'})).to.equal(true);
+      expect(fn({data: 'hello', operator: 'regex', value: '^hi'})).to.equal(false);
+    });
+
     it('compares field emptiness', () => {
       expect(fn({data: [], operator: 'empty'})).to.equal(true);
       expect(fn({data: false, operator: 'not-empty'})).to.equal(true);

--- a/lib/validators/built-in/conditional-required.js
+++ b/lib/validators/built-in/conditional-required.js
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+import { getComponentName, fieldProp } from '../../utils/references';
+import labelUtil from '../../utils/label';
+import { isEmpty, compare } from '../../utils/comparators';
+
+export const label = 'Conditionally Required',
+  description = 'Some fields are required for publication, based on other fields',
+  type = 'error';
+
+export function validate(state) {
+  return _.reduce(state.components, (result, component, uri) => {
+    _.forOwn(component, (val, key) => {
+      if (isEmpty(val)) {
+        // first, check empty values. if it's empty, then we should
+        // look in the schema to see if it was required
+        const name = getComponentName(uri),
+          schema = _.get(state, `schemas[${name}][${key}]`),
+          behaviors = schema && schema[fieldProp],
+          conditionalRequired = _.isArray(behaviors) && _.find(behaviors, { fn: 'conditional-required' });
+
+        if (conditionalRequired) {
+          // check the field it's based on, to see if it's actually required here
+          const compareField = conditionalRequired.field,
+            compareSchema = _.get(state, `schemas[${name}][${compareField}]`),
+            compareData = _.get(component, compareField),
+            shouldBeRequired = compare({ data: compareData, operator: conditionalRequired.operator, value: conditionalRequired.value });
+
+          if (shouldBeRequired) {
+            result.push({
+              uri,
+              field: key,
+              location: `${labelUtil(name)} » ${labelUtil(key, schema)}`,
+              preview: `(based on ${labelUtil(compareField, compareSchema)})`
+            });
+          }
+        }
+      }
+    });
+
+    return result;
+  }, []);
+}

--- a/lib/validators/built-in/conditional-required.test.js
+++ b/lib/validators/built-in/conditional-required.test.js
@@ -1,0 +1,84 @@
+import * as lib from './conditional-required';
+
+describe('validators: required', () => {
+  it('has a label', () => expect(lib.label).to.not.equal(null));
+  it('has a description', () => expect(lib.description).to.not.equal(null));
+  it('returns errors', () => expect(lib.type).to.equal('error'));
+
+  describe('validate', () => {
+    const fn = lib.validate,
+      uri = 'domain.com/components/foo/instances/bar',
+      name = 'foo';
+
+    it('passes if no components', () => {
+      expect(fn({})).to.eql([]);
+    });
+
+    it('passes if no required fields', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: null }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: 'text'
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
+    it('passes if required field with data', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: 'hello' }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: ['text', {fn: 'conditional-required'}]
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
+    it('passes if required field when it isn\'t required', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: null, b: 1 }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: ['text', {fn: 'conditional-required', field: 'b', operator: '>', value: 1}]
+            },
+            b: {}
+          }
+        }
+      })).to.eql([]);
+    });
+
+    it('fails if required field when it is required', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: '', b: 2 }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: ['text', {fn: 'conditional-required', field: 'b', operator: '>', value: 1}]
+            },
+            b: {}
+          }
+        }
+      })).to.eql([{
+        uri,
+        field: 'a',
+        location: 'Foo » A',
+        preview: '(based on B)'
+      }]);
+    });
+  });
+});

--- a/lib/validators/built-in/required.js
+++ b/lib/validators/built-in/required.js
@@ -1,28 +1,16 @@
 import _ from 'lodash';
 import { getComponentName, fieldProp } from '../../utils/references';
 import labelUtil from '../../utils/label';
+import { isEmpty } from '../../utils/comparators';
 
 export const label = 'Required',
   description = 'Some fields are required for publication',
   type = 'error';
 
-function isFieldEmpty(val) {
-  if (_.isArray(val) || _.isObject(val)) {
-    return _.isEmpty(val);
-  } else if (_.isString(val)) {
-    return val.length === 0; // emptystring is empty
-  } else if (_.isNull(val) || _.isUndefined(val)) {
-    return true; // null and undefined are empty
-  } else {
-    // numbers, booleans, etc are never empty
-    return false;
-  }
-}
-
 export function validate(state) {
   return _.reduce(state.components, (result, component, uri) => {
     _.forOwn(component, (val, key) => {
-      if (isFieldEmpty(val)) {
+      if (isEmpty(val)) {
         // first, check empty values. if it's empty, then we should
         // look in the schema to see if it was required
         const name = getComponentName(uri),


### PR DESCRIPTION
Now that we have Vue, we can do some cool behaviors that were impossible before. Announcing `reveal` and `conditional-required`!

# Reveal

![](https://dl.dropboxusercontent.com/s/3yze1pokux4w8yx/FD60C5D8-C43A-4454-899B-70F03A7FE5AA-903-0000A3095FBC8B6A.gif?dl=0)

* conditionally hide or show a field based on another field
* uses a new `comparators` library to keep things consistent

# Conditional Required

![](https://dl.dropboxusercontent.com/s/gt667181f9cspqt/D01985F7-B3F3-4D29-A90C-CEF2B0EC1128-903-0000AB8101F5CB30.gif?dl=0)

* conditionally makes a field required or not, based on another field
* uses `comparators` library
* includes a built-in validator