### PR TITLE
Fixes missing settings buttons

### DIFF
--- a/lib/core-data/groups.js
+++ b/lib/core-data/groups.js
@@ -96,7 +96,7 @@ export function getSettingsFields(data, schema) {
     // note: no sections if there isn't a manual settings group
     return {
       fields: _.reduce(schema, (fields, fieldData, fieldName) => {
-        if (_.get(schema, `${fieldName}.${displayProp}`) === 'settings') {
+        if (_.get(fieldData, displayProp) === 'settings') {
           fields[fieldName] = data[fieldName];
         }
         return fields;

--- a/lib/core-data/groups.js
+++ b/lib/core-data/groups.js
@@ -94,13 +94,15 @@ export function getSettingsFields(data, schema) {
   } else {
     // look for all fields with `_display: settings`
     // note: no sections if there isn't a manual settings group
-    return { fields: _.reduce(data, function (fields, fieldData, fieldName) {
-      if (_.get(schema, `${fieldName}.${displayProp}`) === 'settings') {
-        fields[fieldName] = fieldData;
-      }
-
-      return fields;
-    }, {}), sections: [] };
+    return {
+      fields: _.reduce(schema, (fields, fieldData, fieldName) => {
+        if (_.get(schema, `${fieldName}.${displayProp}`) === 'settings') {
+          fields[fieldName] = data[fieldName];
+        }
+        return fields;
+      }, {}),
+      sections: []
+    };
   }
 }
 


### PR DESCRIPTION
Problem: The settings button is sometimes missing on selectors for several components -- e.g. divider, divider-short, greatest-hits.

Explanation: Whether a settings button is shown on a selector is determined by the results of `getSettingsFields`, which takes in a component instance's data and schema and returns a mapping of all settings fields to their values. Currently, that fnc is not properly detecting fields with `_display: settings`. This is because it is iterating over the properties of the data instead of the schema. If the data does not include a field, it will not appear in the returned fields object (even as `undefined`). If an instance's fields are all empty, the fnc will return an empty fields object, and the settings button will not appear.

Solution: This change modifies `getSettingsFields` to iterate over the schema fields instead of `data`'s properties. Settings fields that do not appear in the data _will_ appear in the returned fields object.