### PR TITLE
Fixes missing textarea dep import

### DIFF
--- a/behaviors/textarea.vue
+++ b/behaviors/textarea.vue
@@ -28,6 +28,7 @@
   import keycode from 'keycode';
   import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
   import { setCaret, isFirstField } from '../lib/forms/field-helpers';
+  import _ from 'lodash';
 
   export default {
     props: ['name', 'data', 'schema', 'args'],


### PR DESCRIPTION
Adds missing lodash import in textarea.vue.

Discovered while working on [Trello](https://trello.com/c/atD68jsc/146-svg). 