### PR TITLE
feat: list of protected uris to hide the unpublish button

### DIFF
--- a/lib/drawers/publish-page.vue
+++ b/lib/drawers/publish-page.vue
@@ -9,7 +9,7 @@
         <span class="status-link-text">View public page</span>
       </a>
       <ui-button v-if="isScheduled" class="status-undo-button" buttonType="button" color="red" @click.stop="unschedulePage">Unschedule</ui-button>
-      <ui-button v-else-if="isPublished" class="status-undo-button" buttonType="button" color="red" @click.stop="unpublishPage">Unpublish</ui-button>
+      <ui-button v-else-if="isPublished && !isUnpublishProtected" class="status-undo-button" buttonType="button" color="red" @click.stop="unpublishPage">Unpublish</ui-button>
       <ui-button v-else-if="isArchived" class="status-undo-button" buttonType="button" color="red" @click.stop="archivePage(false)">Unarchive</ui-button>
     </div>
 
@@ -140,6 +140,11 @@
       isLayoutPublished: state => state.layout.state.published,
       headComponents: state => state.page.data.head,
       hasChanges: state => hasPageChanges(state),
+      isUnpublishProtected() {
+        const protectedUris = _.get(window, 'kiln.unpublishProtectedUris', []);
+
+        return protectedUris.includes(this.uri);
+      },
       statusMessage() {
         if (this.isScheduled) {
           return `Scheduled ${distanceInWordsToNow(this.scheduledDate, { addSuffix: true })}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "10.2.2",
+  "version": "10.2.3-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "10.2.3-dev.0",
+  "version": "10.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "10.2.2",
+  "version": "10.2.3-dev.0",
   "description": "Editor tools for Clay",
   "template": "template.handlebars",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "10.2.3-dev.0",
+  "version": "10.2.3",
   "description": "Editor tools for Clay",
   "template": "template.handlebars",
   "scripts": {


### PR DESCRIPTION
Reads a list of page uris from `window.kiln.unpublishProtectedUris = ['domain.com/_pages/abc123']` and hides the unpublish button for those.