### PR TITLE
🍕 fix(validators): suppress [object Object] preview for complex-list min/max errors

### DIFF
--- a/inputs/complex-list.vue
+++ b/inputs/complex-list.vue
@@ -50,36 +50,41 @@
 </docs>
 
 <template>
-  <transition mode="out-in" name="hide-show" @after-enter="onResize">
-    <div class="complex-list" v-if="items.length" v-click-outside="unselect">
-      <ui-textbox v-if="isFilterable" type="text" label="Filter List"
-        v-model.trim="query"
-        :autofocus="true"
-        :floatingLabel="true"></ui-textbox>
-      <transition-group mode="out-in" name="hide-show" tag="div" class="complex-list-items" @after-enter="onListResize">
-        <item v-for="(item, index) in matches"
-          :index="index"
-          :total="items.length"
-          :originalItems="items"
-          :name="name + '.' + index"
-          :data="item"
-          :schema="args"
-          :key="`complex-list-items-${index}`"
-          :disabled="disabled"
-          :isFiltered="isFiltered"
-          :currentItem="currentItem"
-          :isBelowMaxLength="isBelowMaxLength"
-          :initialFocus="initialFocus"
-          @current="onCurrentChange"
-          @removeItem="removeItem"
-          @moveItem="moveItem"
-          @addItem="addItem"
-          v-dynamic-events="customEvents">
-        </item>
-      </transition-group>
+  <div class="complex-list-wrapper">
+    <transition mode="out-in" name="hide-show" @after-enter="onResize">
+      <div class="complex-list" v-if="items.length" v-click-outside="unselect">
+        <ui-textbox v-if="isFilterable" type="text" label="Filter List"
+          v-model.trim="query"
+          :autofocus="true"
+          :floatingLabel="true"></ui-textbox>
+        <transition-group mode="out-in" name="hide-show" tag="div" class="complex-list-items" @after-enter="onListResize">
+          <item v-for="(item, index) in matches"
+            :index="index"
+            :total="items.length"
+            :originalItems="items"
+            :name="name + '.' + index"
+            :data="item"
+            :schema="args"
+            :key="`complex-list-items-${index}`"
+            :disabled="disabled"
+            :isFiltered="isFiltered"
+            :currentItem="currentItem"
+            :isBelowMaxLength="isBelowMaxLength"
+            :initialFocus="initialFocus"
+            @current="onCurrentChange"
+            @removeItem="removeItem"
+            @moveItem="moveItem"
+            @addItem="addItem"
+            v-dynamic-events="customEvents">
+          </item>
+        </transition-group>
+      </div>
+      <ui-button v-else buttonType="button" color="accent" icon="add" :disabled="disabled" @click.stop.prevent="addItem(-1)">Add Items</ui-button>
+    </transition>
+    <div class="ui-textbox__feedback" v-if="errorMessage">
+      <div class="ui-textbox__feedback-text">{{ errorMessage }}</div>
     </div>
-    <ui-button v-else buttonType="button" color="accent" icon="add" :disabled="disabled" @click.stop.prevent="addItem(-1)">Add Items</ui-button>
-  </transition>
+  </div>
 </template>
 
 <script>
@@ -89,6 +94,7 @@
   import UiButton from 'keen/UiButton';
   import UiTextbox from 'keen/UiTextbox';
   import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
+  import { getValidationError } from '../lib/forms/field-helpers';
   import { DynamicEvents } from './mixins';
 
   /**
@@ -180,6 +186,9 @@
         } else {
           return true; // if there's no max length, or it's not enforced, don't worry about it!
         }
+      },
+      errorMessage() {
+        return getValidationError(this.items, _.get(this.schema, '_has.validate'), this.$store, this.name);
       }
     },
     methods: {

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -134,8 +134,8 @@ export function getFieldData(store, prop, path, uri) {
 function errorMessages(validate = {}, isLengthy) {
   return {
     required: validate.requiredMessage || 'Please fill out this field',
-    min: validate.minMessage || isLengthy ? `Please enter at least ${validate.min} characters` : `Please enter a value of ${validate.min} or above`,
-    max: validate.maxMessage || isLengthy ? `Please enter fewer than ${validate.max + 1} characters` : `Please enter a value of ${validate.max} or below`,
+    min: validate.minMessage || (isLengthy ? `Please enter at least ${validate.min} characters` : `Please enter a value of ${validate.min} or above`),
+    max: validate.maxMessage || (isLengthy ? `Please enter fewer than ${validate.max + 1} characters` : `Please enter a value of ${validate.max} or below`),
     pattern: validate.patternMessage || `Please match the pattern "/${validate.pattern}/ig"`
   };
 }

--- a/lib/validators/built-in/max.js
+++ b/lib/validators/built-in/max.js
@@ -8,11 +8,18 @@ export const label = 'Max',
   description = 'Some fields must be less than a certain length (or value)',
   type = 'error';
 
+// Returns true when a field value is an array that contains non-primitive items
+// (e.g. complex-list slot objects, simple-list tag objects like {text: "foo"}).
+// Calling getPlaintextValue on these produces "[object Object]" noise.
+function hasNonPrimitiveArrayValue(field) {
+  return Array.isArray(field.value) && field.value.some((item) => item !== null && typeof item === 'object');
+}
+
 export function validate(state) {
   let errors = [];
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
-    if (!isValid(field, componentData, 'max') && (field.type === 'component-list' || field.type === 'complex-list')) {
+    if (!isValid(field, componentData, 'max') && (field.type === 'component-list' || hasNonPrimitiveArrayValue(field))) {
       errors.push({
         uri,
         location: `${labelComponent(uri)} » ${labelUtil(field.name)}`

--- a/lib/validators/built-in/max.js
+++ b/lib/validators/built-in/max.js
@@ -12,7 +12,7 @@ export function validate(state) {
   let errors = [];
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
-    if (!isValid(field, componentData, 'max') && field.type === 'component-list') {
+    if (!isValid(field, componentData, 'max') && (field.type === 'component-list' || field.type === 'complex-list')) {
       errors.push({
         uri,
         location: `${labelComponent(uri)} » ${labelUtil(field.name)}`

--- a/lib/validators/built-in/min.js
+++ b/lib/validators/built-in/min.js
@@ -12,7 +12,7 @@ export function validate(state) {
   let errors = [];
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
-    if (!isValid(field, componentData, 'min') && field.type === 'component-list') {
+    if (!isValid(field, componentData, 'min') && (field.type === 'component-list' || field.type === 'complex-list')) {
       errors.push({
         uri,
         location: `${labelComponent(uri)} » ${labelUtil(field.name)}`

--- a/lib/validators/built-in/min.js
+++ b/lib/validators/built-in/min.js
@@ -8,11 +8,18 @@ export const label = 'Minimum',
   description = 'Some fields must be more than a certain length (or value)',
   type = 'error';
 
+// Returns true when a field value is an array that contains non-primitive items
+// (e.g. complex-list slot objects, simple-list tag objects like {text: "foo"}).
+// Calling getPlaintextValue on these produces "[object Object]" noise.
+function hasNonPrimitiveArrayValue(field) {
+  return Array.isArray(field.value) && field.value.some((item) => item !== null && typeof item === 'object');
+}
+
 export function validate(state) {
   let errors = [];
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
-    if (!isValid(field, componentData, 'min') && (field.type === 'component-list' || field.type === 'complex-list')) {
+    if (!isValid(field, componentData, 'min') && (field.type === 'component-list' || hasNonPrimitiveArrayValue(field))) {
       errors.push({
         uri,
         location: `${labelComponent(uri)} » ${labelUtil(field.name)}`


### PR DESCRIPTION
## Problem

<img width="364" height="427" alt="image" src="https://github.com/user-attachments/assets/2ef55096-dc79-47c2-a42a-db8b8aa6b519" />
<img width="661" height="241" alt="image" src="https://github.com/user-attachments/assets/cea20a65-7024-4b95-9e64-2681ea9a152e" />



When a field that stores an array of objects fails \`min\` or \`max\` validation, the publish tab shows a garbled preview:

```
Audio Playlist » Playlist Articles [object Object],[object Object],[object Object]
```

This affects any input type whose value is an array of non-primitive items — not just \`complex-list\`, but also \`simple-list\` fields that store tag objects like \`[{text: \"audio\"}]\`.

## Root Cause

Both \`min.js\` and \`max.js\` validators have two branches when a violation is found:

1. **\`component-list\`** fields — show only the location, no preview (correct)
2. **Everything else** — call \`getPlaintextValue(field.value)\` and show it as a preview

\`getPlaintextValue\` does \`new String(value)\`. For an array of objects that produces \`[object Object],[object Object],...\`. The original guard only excluded \`component-list\` by \`field.type\`, which missed:

- \`complex-list\` fields (type \`'complex-list'\`)
- \`simple-list\` fields storing tag objects like \`[{text: \"foo\"}]\` (type \`'editable-field'\`, but value is still an array of objects)
- Any future input type that may store arrays of objects

## Fix

Replace the hard-coded \`field.type\` check with a runtime \`hasNonPrimitiveArrayValue()\` helper that detects any array whose items are objects, regardless of the input type. Fields matching this condition are treated the same as \`component-list\` — the violation is reported with just the component name and field label, no preview.

```js
function hasNonPrimitiveArrayValue(field) {
  return Array.isArray(field.value) && field.value.some((item) => item !== null && typeof item === 'object');
}
```

## Files Changed

- \`lib/validators/built-in/min.js\`
- \`lib/validators/built-in/max.js\`