### PR TITLE
🍕 Keep iframe overlays from covering the page in edit mode

### DIFF
--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -38,7 +38,7 @@ function addDiffingChecksum(uri, el) {
 }
 
 /**
- * determine whether an iframe needs a click-blocking overlay
+ * determine whether an iframe needs a click-blocking overlay it doesn't have yet
  * an iframe inside a non-rendered subtree cannot capture a click, so overlaying
  * it achieves nothing and leaves stray markup in the component. this is common:
  * analytics components ship iframes inside <noscript> (which browsers hide when
@@ -49,7 +49,7 @@ function addDiffingChecksum(uri, el) {
  * @returns {boolean}
  */
 function needsOverlay(iframe) {
-  return iframe.offsetParent !== null;
+  return !iframe.classList.contains(overlayClass) && iframe.offsetParent !== null;
 }
 
 /**
@@ -78,7 +78,7 @@ function anchorOverlay(parent) {
  */
 export function addIframeOverlays(el) {
   const iframes = findAll(el, 'iframe'),
-    iframesWithoutOverlays = _.filter(iframes, iframe => !iframe.classList.contains(overlayClass) && needsOverlay(iframe));
+    iframesWithoutOverlays = _.filter(iframes, needsOverlay);
 
   _.each(iframesWithoutOverlays, (iframe) => {
     let overlay = create('<div data-ignore class="iframe-overlay-div"></div>');

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -19,6 +19,11 @@ import logger from '../utils/log';
 
 const log = logger(__filename);
 
+// position values that establish a containing block for absolutely positioned
+// descendants. anything else (static, or a value the browser won't resolve)
+// does not, so an overlay inside it would escape to a further ancestor
+const positionedValues = ['relative', 'absolute', 'fixed', 'sticky'];
+
 /**
  * add checksum for more accurate dom diffing when re-rendering components
  * note: checksum is based on component data
@@ -33,18 +38,52 @@ function addDiffingChecksum(uri, el) {
 }
 
 /**
+ * determine whether an iframe needs a click-blocking overlay
+ * an iframe inside a non-rendered subtree cannot capture a click, so overlaying
+ * it achieves nothing and leaves stray markup in the component. this is common:
+ * analytics components ship iframes inside <noscript> (which browsers hide when
+ * scripting is enabled) and ad/tracking components ship display:none iframes
+ * note: fixed-position iframes also report a null offsetParent and are skipped —
+ * the same tradeoff showVisible() makes in utils/component-elements
+ * @param {Element} iframe
+ * @returns {boolean}
+ */
+function needsOverlay(iframe) {
+  return iframe.offsetParent !== null;
+}
+
+/**
+ * make the iframe's own parent the containing block for its overlay
+ * the overlay is absolutely positioned at 100%/100%, so it fills the nearest
+ * positioned ancestor. when the parent is unpositioned that ancestor may be an
+ * arbitrary distance up the tree, and the overlay then covers — and swallows
+ * every click on — unrelated parts of the page, locking editors out entirely.
+ * note: this makes the parent a containing block for any absolutely positioned
+ * descendants that previously resolved against a further ancestor. that only
+ * happens in edit mode, and only for components that don't already position
+ * their own embed wrapper
+ * @param {Element} parent
+ */
+function anchorOverlay(parent) {
+  if (parent && !_.includes(positionedValues, getComputedStyle(parent).position)) {
+    parent.style.position = 'relative';
+  }
+}
+
+/**
  * add iframe overlays to any iframes inside a component
  * this blocks those iframes from capturing the clicks,
  * which allows us to preview embeds and videos while editing them
  * @param {Element} el
  */
-function addIframeOverlays(el) {
+export function addIframeOverlays(el) {
   const iframes = findAll(el, 'iframe'),
-    iframesWithoutOverlays = _.filter(iframes, iframe => !iframe.classList.contains(overlayClass));
+    iframesWithoutOverlays = _.filter(iframes, iframe => !iframe.classList.contains(overlayClass) && needsOverlay(iframe));
 
   _.each(iframesWithoutOverlays, (iframe) => {
     let overlay = create('<div data-ignore class="iframe-overlay-div"></div>');
 
+    anchorOverlay(iframe.parentElement);
     insertAfter(iframe, overlay);
     iframe.classList.add(overlayClass);
   });

--- a/lib/decorators/index.test.js
+++ b/lib/decorators/index.test.js
@@ -1,0 +1,95 @@
+import * as lib from './index';
+import { overlayClass } from '../utils/references';
+
+/**
+ * jsdom has no layout engine, so every element reports offsetParent === null.
+ * stub it to simulate an iframe that is (or is not) in a rendered subtree.
+ * @param {Element} el
+ * @param {Element|null} offsetParent
+ */
+function setOffsetParent(el, offsetParent) {
+  Object.defineProperty(el, 'offsetParent', { value: offsetParent, configurable: true });
+}
+
+/**
+ * build a component element containing one iframe
+ * the element is attached to the document because getComputedStyle only resolves
+ * to real values for in-document elements — and decorators always run on
+ * attached elements, since reactive-render replaces the element before
+ * decorating it
+ * @param {string} [parentStyle] inline style for the iframe's wrapper
+ * @returns {object} the component el, its wrapper, and the iframe
+ */
+function stubComponent(parentStyle = '') {
+  const el = document.createElement('div');
+
+  el.innerHTML = `<div class="embed" style="${parentStyle}"><iframe src="https://example.com/embed"></iframe></div>`;
+  document.body.appendChild(el);
+
+  return { el, parent: el.querySelector('.embed'), iframe: el.querySelector('iframe') };
+}
+
+describe('decorators', () => {
+  describe('addIframeOverlays', () => {
+    const fn = lib.addIframeOverlays;
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    test('adds an overlay after a rendered iframe', () => {
+      const { el, iframe } = stubComponent();
+
+      setOffsetParent(iframe, document.body);
+      fn(el);
+
+      expect(iframe.nextElementSibling.className).toBe('iframe-overlay-div');
+      expect(iframe.nextElementSibling.hasAttribute('data-ignore')).toBe(true);
+      expect(iframe.classList.contains(overlayClass)).toBe(true);
+    });
+
+    test('does not add a second overlay to an already-overlaid iframe', () => {
+      const { el, iframe } = stubComponent();
+
+      setOffsetParent(iframe, document.body);
+      fn(el);
+      fn(el);
+
+      expect(el.querySelectorAll('.iframe-overlay-div')).toHaveLength(1);
+    });
+
+    test('skips iframes that are not rendered', () => {
+      // analytics components ship iframes inside <noscript> and ad/tracking
+      // components ship display:none iframes. both report a null offsetParent,
+      // cannot capture a click, and only leave stray markup if overlaid
+      const { el, iframe } = stubComponent();
+
+      setOffsetParent(iframe, null);
+      fn(el);
+
+      expect(el.querySelector('.iframe-overlay-div')).toBeNull();
+      expect(iframe.classList.contains(overlayClass)).toBe(false);
+    });
+
+    test('positions a static parent so the overlay cannot escape it', () => {
+      // the overlay is absolute at 100%/100%. with a static parent it would fill
+      // whatever distant ancestor happens to be positioned, covering unrelated
+      // parts of the page and swallowing every click on them
+      const { el, iframe, parent } = stubComponent();
+
+      setOffsetParent(iframe, document.body);
+      fn(el);
+
+      expect(parent.style.position).toBe('relative');
+    });
+
+    test('leaves an already-positioned parent alone', () => {
+      const { el, iframe, parent } = stubComponent('position: absolute');
+
+      setOffsetParent(iframe, document.body);
+      fn(el);
+
+      expect(parent.style.position).toBe('absolute');
+    });
+  });
+});


### PR DESCRIPTION
## TL;DR — for reviewers short on time

- **Risk:** low — one decorator, edit mode only. Both changes narrow when and where an overlay is created; neither adds an overlay anywhere it wasn't already.
- **If you only review one thing:** [`lib/decorators/index.js` → `anchorOverlay` L55–L71](https://github.com/clay/clay-kiln/blob/fb6981e9/lib/decorators/index.js#L55-L71) — this is the part that can actually lock an editor out of a page, and the one place where the fix mutates site layout.
- **Changes, in logical review order** (each link jumps to where to start reading):
  1. [`lib/decorators/index.js` → `anchorOverlay` L55–L71](https://github.com/clay/clay-kiln/blob/fb6981e9/lib/decorators/index.js#L55-L71) — the core fix. Pins the overlay's containing block to the iframe's own parent so it can never extend past its wrapper. Uses [`positionedValues` L22–L25](https://github.com/clay/clay-kiln/blob/fb6981e9/lib/decorators/index.js#L22-L25).
  2. [`lib/decorators/index.js` → `needsOverlay` L40–L53](https://github.com/clay/clay-kiln/blob/fb6981e9/lib/decorators/index.js#L40-L53) — skips iframes that aren't rendered, so unrenderable analytics iframes stop collecting overlays.
  3. [`lib/decorators/index.js` → `addIframeOverlays` L73–L90](https://github.com/clay/clay-kiln/blob/fb6981e9/lib/decorators/index.js#L73-L90) — wires both in. Now exported, following the `select.js` convention for testable helpers.
  4. [`lib/decorators/index.test.js` L33](https://github.com/clay/clay-kiln/blob/fb6981e9/lib/decorators/index.test.js#L33) — new file, 5 tests. There was no coverage for this decorator before.

---

## Feature Info

#### Jira Ticket Url

- None yet. Found while investigating an editor report that a Curbed staging article couldn't be edited — happy to file a ticket and add the ID to the title if we want one on the board.

#### Description

`addIframeOverlays` inserts a `position: absolute; width: 100%; height: 100%` div beside every iframe in a component so the iframe can't capture clicks, letting editors select and edit components that contain embeds. Two gaps let that overlay block editing rather than enable it.

**It overlaid iframes that are never rendered.** Analytics components ship an iframe inside `<noscript>`, which browsers hide when scripting is enabled. `core-data/api.js` fetches component HTML and parses full documents with `DOMParser`, which has scripting disabled — so `<noscript>` contents come back as real elements, get adopted into the live DOM on re-render, and reach decoration. The overlays added to them block nothing and leave stray markup in the component.

**The overlay fills its nearest positioned ancestor, not the iframe.** That's fine for components that position their own embed wrapper. When the iframe's parent is unpositioned, the containing block is whatever positioned element happens to be next up the tree — possibly the layout root. The overlay then stretches across unrelated parts of the page and swallows every click on them. To an editor that is indistinguishable from the page being broken, and it's hard to diagnose because the element looks correctly sized in the inspector relative to the wrong parent.

This is defense in depth for [clay/claycli#256](https://github.com/clay/claycli/pull/256), which stops component `client.js` from running in edit mode. That PR removes the immediate trigger — ad and comment components were injecting iframes into the editing surface — but Kiln shouldn't be able to produce a page-covering overlay regardless of where an iframe came from, and server-rendered embeds (`html-embed` in particular, where the markup is editor-supplied) can still land in an unpositioned wrapper.

#### QA Testing Notes

- Open an article with an embed (`html-embed`, YouTube, Spotify) with `?edit=true` and confirm the embed is still click-blocked: clicking it selects the component instead of interacting with the iframe.
- Confirm clicks land normally everywhere else on the page — that's the regression this fixes.
- Inspect a component whose embed wrapper is unpositioned (`coral-talk` is one) and confirm the overlay is bounded by the wrapper rather than stretching past it.
- Confirm no `.iframe-overlay-div` is emitted next to a `<noscript>` analytics iframe (`gtm` is the clearest case).

#### Validation Points

- **`offsetParent` for hidden iframes:** null inside any `display: none` subtree, which is how browsers treat `<noscript>` when scripting is on. Reusing the idiom `showVisible()` already uses in `utils/component-elements`, including its known tradeoff: fixed-position iframes also report null and are skipped. Skipping an overlay is the safe direction — a fixed iframe's sibling overlay was already positioned against the wrong box.
- **Mutating `parent.style.position`:** setting `relative` on an element with no offsets doesn't move it, but it does make that parent the containing block for any absolutely positioned descendant that previously resolved against a further ancestor. Scoped as tightly as possible — the immediate parent only, edit mode only, and only when the parent isn't already positioned.
- **Late-rendering iframes:** an iframe hidden at decoration time gets no overlay. `reactive-render` re-decorates after every re-render, so it picks one up then. With claycli#256 in place, edit mode no longer injects iframes after load anyway.
- **Tests:** `lib/decorators`, `lib/component-data` — 5 suites pass, including the new file. `lib/component-data/actions.test.js` crashes the worker with an unhandled `Save failed, reverting` rejection under Node 20; that reproduces identically on `master` with this change reverted, and it's what stalls a full `jest` run.
- `npm run lint` clean.

Made with [Cursor](https://cursor.com)
